### PR TITLE
feat: add sync-link command and improve repo management

### DIFF
--- a/src/command/sync-link.md
+++ b/src/command/sync-link.md
@@ -1,0 +1,15 @@
+---
+description: Link this computer to an existing sync repo
+---
+
+Use the opencode_sync tool with command "link".
+This command is for linking a second (or additional) computer to an existing sync repo that was created on another machine.
+
+IMPORTANT: This will OVERWRITE the local OpenCode configuration with the contents from the synced repo. The only thing preserved is the local overrides file (opencode-synced.overrides.jsonc).
+
+If the user provides a repo name argument, pass it as name="repo-name".
+If no repo name is provided, the tool will automatically search for common sync repo names.
+
+After linking:
+- Remind the user to restart OpenCode to apply the synced config
+- If they want to enable secrets sync, they should run /sync-enable-secrets

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ export const OpencodeConfigSync: Plugin = async (ctx) => {
     description: 'Manage OpenCode config sync with a GitHub repo',
     args: {
       command: tool.schema
-        .enum(['status', 'init', 'pull', 'push', 'enable-secrets', 'resolve'])
+        .enum(['status', 'init', 'link', 'pull', 'push', 'enable-secrets', 'resolve'])
         .describe('Sync command to execute'),
       repo: tool.schema.string().optional().describe('Repo owner/name or URL'),
       owner: tool.schema.string().optional().describe('Repo owner'),
@@ -116,6 +116,11 @@ export const OpencodeConfigSync: Plugin = async (ctx) => {
             private: args.private,
             extraSecretPaths: args.extraSecretPaths,
             localRepoPath: args.localRepoPath,
+          });
+        }
+        if (args.command === 'link') {
+          return await service.link({
+            repo: args.repo ?? args.name,
           });
         }
         if (args.command === 'pull') {

--- a/src/sync/commit.ts
+++ b/src/sync/commit.ts
@@ -73,8 +73,8 @@ function sanitizeMessage(message: string): string {
 
 async function getDiffSummary($: Shell, repoDir: string): Promise<string> {
   try {
-    const nameStatus = await $`git -C ${repoDir} diff --name-status`.text();
-    const stats = await $`git -C ${repoDir} diff --stat`.text();
+    const nameStatus = await $`git -C ${repoDir} diff --name-status`.quiet().text();
+    const stats = await $`git -C ${repoDir} diff --stat`.quiet().text();
     return [nameStatus.trim(), stats.trim()].filter(Boolean).join('\n');
   } catch {
     return '';


### PR DESCRIPTION
Implement command to connect additional machines to an existing sync repository with automatic detection of common repository names. Improve repository handling by adding a logger, silencing git/gh commands, and ensuring initial sync occurs during setup. Update documentation with removal instructions and information about the new linking workflow.