### PR TITLE
feat: add 1Password secrets backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,11 +17,6 @@
 - **PR Titles**: PR titles MUST follow conventional commit format (e.g., `fix: descriptive title`). This is enforced by GitHub checks.
 - **Workflow**: Run `bun run check` and `bun run test` before creating a PR.
 
-## Branch Policy
-
-- **main**: used only for upstream PRs to `iHildy/opencode-synced` (maintainer repo).
-- **fork-release**: fork-only release automation for `opencode-synced-1password`; keep release workflows/docs there.
-
 ## Code Style Guidelines
 
 ### Imports & Module System

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,4 +69,4 @@
 
 - **Type**: ES Module package for opencode plugin system
 - **Target**: Bun runtime, ES2021+
-- **Purpose**: Sync global opencode config across machines via GitHub
+- **Purpose**: Sync global opencode config across machines via GitHub, with optional secrets support (e.g., 1Password backend)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,11 @@
 - **PR Titles**: PR titles MUST follow conventional commit format (e.g., `fix: descriptive title`). This is enforced by GitHub checks.
 - **Workflow**: Run `bun run check` and `bun run test` before creating a PR.
 
+## Branch Policy
+
+- **main**: used only for upstream PRs to `iHildy/opencode-synced` (maintainer repo).
+- **fork-release**: fork-only release automation for `opencode-synced-1password`; keep release workflows/docs there.
+
 ## Code Style Guidelines
 
 ### Imports & Module System

--- a/docs/1Password.md
+++ b/docs/1Password.md
@@ -31,8 +31,7 @@ Add a new optional config block:
     "vault": "Personal",
     "documents": {
       "authJson": "opencode-auth.json",
-      "mcpAuthJson": "opencode-mcp-auth.json",
-      "envFile": ".env.opencode" // optional: store+restore the env file too
+      "mcpAuthJson": "opencode-mcp-auth.json"
     }
   }
 }
@@ -79,7 +78,7 @@ documents.authJson required
 
 documents.mcpAuthJson required
 
-documents.envFile optional
+documents.authJson and documents.mcpAuthJson must be unique
 
 3) Add a SecretsBackend interface
 Internal interface:
@@ -113,20 +112,18 @@ if local file doesn’t exist: skip.
 
 create doc if missing; otherwise edit doc.
 
-Files to manage:
+Files to manage (XDG-aware):
 
-~/.local/share/opencode/auth.json
+Linux/macOS: ~/.local/share/opencode/auth.json and ~/.local/share/opencode/mcp-auth.json
 
-~/.local/share/opencode/mcp-auth.json
-
-Optional: ~/.config/opencode/.env.opencode (only if configured)
+Windows: %LOCALAPPDATA%\opencode\auth.json and %LOCALAPPDATA%\opencode\mcp-auth.json
 
 5) Wire backend into sync lifecycle
 Hook points:
 
 After /sync-pull applies repo changes -> call backend.pull()
 
-Before /sync-push commits/pushes -> call backend.push()
+After /sync-push successfully commits/pushes (or when no repo changes) -> call backend.push()
 
 Add explicit commands:
 

--- a/docs/1Password.md
+++ b/docs/1Password.md
@@ -88,7 +88,7 @@ pull(): Promise<void> // 1P -> local files
 
 push(): Promise<void> // local files -> 1P
 
-status(): Promise<{ ok: boolean; message: string }> (optional)
+status(): Promise<string> (optional)
 
 4) Implement OnePasswordBackend
 Implementation rules:

--- a/docs/1Password.md
+++ b/docs/1Password.md
@@ -1,0 +1,197 @@
+# Fork Feature: 1Password Secrets Backend (NO secrets in git)
+
+## Problem
+Upstream `opencode-synced` can sync OpenCode secrets by committing:
+- `~/.local/share/opencode/auth.json`
+- `~/.local/share/opencode/mcp-auth.json`
+
+We want to keep using the plugin for config/sessions, but **never store tokens in git**.
+
+## Goal
+Add an optional secrets backend to this plugin:
+- `auth.json` and `mcp-auth.json` are stored in **1Password** (as opaque blobs)
+- they are **pulled** from 1Password after syncing config
+- they are **pushed** back to 1Password when changed
+- they are **never committed** to git (even if `includeSecrets: true`)
+- keep everything else working exactly like upstream
+
+## Non-goals
+- Don’t parse or reinterpret `auth.json` / `mcp-auth.json` structure.
+- Don’t implement a filesystem watcher daemon. Keep it command-based.
+- Don’t leak secrets in logs/errors.
+
+## Configuration (add to opencode-synced.jsonc)
+Add a new optional config block:
+
+```jsonc
+{
+  "includeSecrets": false,
+  "secretsBackend": {
+    "type": "1password",
+    "vault": "Personal",
+    "documents": {
+      "authJson": "opencode-auth.json",
+      "mcpAuthJson": "opencode-mcp-auth.json",
+      "envFile": ".env.opencode" // optional: store+restore the env file too
+    }
+  }
+}
+```
+
+Rules:
+
+If secretsBackend.type is missing, run upstream behavior.
+
+If type === "1password", auth.json and mcp-auth.json must NOT be included in git sync, regardless of includeSecrets.
+
+1Password Storage Approach
+Use 1Password Document items to store the raw files.
+
+Required CLI operations (execute via child process; never print file contents):
+
+op document get <name> --vault <vault> --out-file <path>
+
+op document create --vault <vault> <file> --title <name>
+
+op document edit <name> --vault <vault> <file>
+
+Implementation Plan (do in order)
+1) Locate current secret sync logic
+Search the repo for:
+
+includeSecrets
+
+auth.json / mcp-auth.json
+
+extraSecretPaths
+
+/sync-pull /sync-push
+Identify the exact function(s) that assemble the list of paths to copy/commit.
+
+2) Add config typing + validation
+Extend config types to include secretsBackend.
+
+Validate:
+
+vault required
+
+documents.authJson required
+
+documents.mcpAuthJson required
+
+documents.envFile optional
+
+3) Add a SecretsBackend interface
+Internal interface:
+
+pull(): Promise<void> // 1P -> local files
+
+push(): Promise<void> // local files -> 1P
+
+status(): Promise<{ ok: boolean; message: string }> (optional)
+
+4) Implement OnePasswordBackend
+Implementation rules:
+
+Use child_process to call op.
+
+Detect if op is installed; return a clear, non-secret error.
+
+For pull:
+
+op document get <name> --vault <vault> --out-file <tmp>
+
+atomically write to target path (write temp + rename)
+
+set restrictive perms (0600) where possible
+
+If document is missing, do not fail hard; just skip.
+
+For push:
+
+if local file doesn’t exist: skip.
+
+create doc if missing; otherwise edit doc.
+
+Files to manage:
+
+~/.local/share/opencode/auth.json
+
+~/.local/share/opencode/mcp-auth.json
+
+Optional: ~/.config/opencode/.env.opencode (only if configured)
+
+5) Wire backend into sync lifecycle
+Hook points:
+
+After /sync-pull applies repo changes -> call backend.pull()
+
+Before /sync-push commits/pushes -> call backend.push()
+
+Add explicit commands:
+
+/sync-secrets-pull
+
+/sync-secrets-push
+
+/sync-secrets-status
+
+6) Enforce “never commit auth files”
+When secretsBackend.type === "1password":
+
+Ensure the git sync path list excludes:
+
+~/.local/share/opencode/auth.json
+
+~/.local/share/opencode/mcp-auth.json
+
+Additionally:
+
+Detect if these files are already tracked in the sync repo.
+
+If yes: stop and print remediation instructions (remove + rewrite history).
+
+7) Change detection (recommended)
+Add lightweight hashing:
+
+compute SHA256 of local auth.json and mcp-auth.json
+
+store last pushed hash in plugin state
+
+only call backend.push() when changed (avoid unnecessary 1P calls)
+
+8) QA / Acceptance Tests (manual)
+Machine A:
+
+Configure secretsBackend=1password
+
+Run /sync-secrets-push (creates docs if missing)
+
+Run /sync-push (must NOT commit auth files)
+
+Machine B:
+
+/sync-link then /sync-pull
+
+/sync-secrets-pull
+
+Verify OpenCode is authenticated without manual token copy
+
+Update tokens:
+
+Run opencode auth login or OpenCode /connect (updates auth.json)
+
+Run /sync-secrets-push
+
+On machine B run /sync-secrets-pull and verify updated auth works
+
+Security Constraints (strict)
+Never print secrets.
+
+Never write secrets into the repo.
+
+Never include secrets in thrown error messages.
+
+Ensure local auth files are chmod 0600 where supported.
+
+If 1Password backend fails, do not destroy local auth files.

--- a/opencode.json
+++ b/opencode.json
@@ -1,1 +1,3 @@
-{}
+{
+  "$schema": "https://opencode.ai/config.json"
+}

--- a/package.json
+++ b/package.json
@@ -22,9 +22,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "dependencies": {
     "@opencode-ai/plugin": "1.0.85"
   },
@@ -51,8 +49,6 @@
     "prepare": "husky"
   },
   "lint-staged": {
-    "*.{js,ts,json}": [
-      "biome check --write --no-errors-on-unmatched"
-    ]
+    "*.{js,ts,json}": ["biome check --write --no-errors-on-unmatched"]
   }
 }

--- a/src/command/sync-secrets-pull.md
+++ b/src/command/sync-secrets-pull.md
@@ -1,0 +1,5 @@
+---
+description: Pull secrets from the configured backend
+---
+
+Use the opencode_sync tool with command "secrets-pull".

--- a/src/command/sync-secrets-push.md
+++ b/src/command/sync-secrets-push.md
@@ -1,0 +1,5 @@
+---
+description: Push secrets to the configured backend
+---
+
+Use the opencode_sync tool with command "secrets-push".

--- a/src/command/sync-secrets-status.md
+++ b/src/command/sync-secrets-status.md
@@ -1,0 +1,5 @@
+---
+description: Show secrets backend status
+---
+
+Use the opencode_sync tool with command "secrets-status".

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,18 @@ export const opencodeConfigSync: Plugin = async (ctx) => {
     description: 'Manage opencode config sync with a GitHub repo',
     args: {
       command: tool.schema
-        .enum(['status', 'init', 'link', 'pull', 'push', 'enable-secrets', 'resolve'])
+        .enum([
+          'status',
+          'init',
+          'link',
+          'pull',
+          'push',
+          'enable-secrets',
+          'resolve',
+          'secrets-pull',
+          'secrets-push',
+          'secrets-status',
+        ])
         .describe('Sync command to execute'),
       repo: tool.schema.string().optional().describe('Repo owner/name or URL'),
       owner: tool.schema.string().optional().describe('Repo owner'),
@@ -181,6 +192,15 @@ export const opencodeConfigSync: Plugin = async (ctx) => {
         }
         if (args.command === 'push') {
           return await service.push();
+        }
+        if (args.command === 'secrets-pull') {
+          return await service.secretsPull();
+        }
+        if (args.command === 'secrets-push') {
+          return await service.secretsPush();
+        }
+        if (args.command === 'secrets-status') {
+          return await service.secretsStatus();
         }
         if (args.command === 'enable-secrets') {
           return await service.enableSecrets({

--- a/src/sync/config.test.ts
+++ b/src/sync/config.test.ts
@@ -77,6 +77,12 @@ describe('normalizeSyncConfig', () => {
     const normalized = normalizeSyncConfig({});
     expect(normalized.includeModelFavorites).toBe(true);
   });
+
+  it('defaults extra path lists when omitted', () => {
+    const normalized = normalizeSyncConfig({ includeSecrets: true });
+    expect(normalized.extraSecretPaths).toEqual([]);
+    expect(normalized.extraConfigPaths).toEqual([]);
+  });
 });
 
 describe('canCommitMcpSecrets', () => {

--- a/src/sync/config.test.ts
+++ b/src/sync/config.test.ts
@@ -87,10 +87,13 @@ describe('normalizeSyncConfig', () => {
 });
 
 describe('normalizeSecretsBackend', () => {
-  it('returns undefined when backend is missing or unknown', () => {
+  it('returns undefined when backend is missing', () => {
     expect(normalizeSecretsBackend(undefined)).toBeUndefined();
+  });
+
+  it('preserves unknown backend types for validation', () => {
     const unknownBackend = { type: 'unknown' } as unknown as SyncConfig['secretsBackend'];
-    expect(normalizeSecretsBackend(unknownBackend)).toBeUndefined();
+    expect(normalizeSecretsBackend(unknownBackend)).toEqual({ type: 'unknown' });
   });
 
   it('normalizes 1password documents', () => {

--- a/src/sync/config.ts
+++ b/src/sync/config.ts
@@ -22,6 +22,16 @@ export interface SyncConfig {
   extraConfigPaths?: string[];
 }
 
+export interface NormalizedSyncConfig extends SyncConfig {
+  includeSecrets: boolean;
+  includeMcpSecrets: boolean;
+  includeSessions: boolean;
+  includePromptStash: boolean;
+  includeModelFavorites: boolean;
+  extraSecretPaths: string[];
+  extraConfigPaths: string[];
+}
+
 export interface SyncState {
   lastPull?: string;
   lastPush?: string;
@@ -47,7 +57,7 @@ export async function chmodIfExists(filePath: string, mode: number): Promise<voi
   }
 }
 
-export function normalizeSyncConfig(config: SyncConfig): SyncConfig {
+export function normalizeSyncConfig(config: SyncConfig): NormalizedSyncConfig {
   const includeSecrets = Boolean(config.includeSecrets);
   const includeModelFavorites = config.includeModelFavorites !== false;
   return {
@@ -67,7 +77,9 @@ export function canCommitMcpSecrets(config: SyncConfig): boolean {
   return Boolean(config.includeSecrets) && Boolean(config.includeMcpSecrets);
 }
 
-export async function loadSyncConfig(locations: SyncLocations): Promise<SyncConfig | null> {
+export async function loadSyncConfig(
+  locations: SyncLocations
+): Promise<NormalizedSyncConfig | null> {
   if (!(await pathExists(locations.syncConfigPath))) {
     return null;
   }

--- a/src/sync/config.ts
+++ b/src/sync/config.ts
@@ -10,7 +10,8 @@ export interface SyncRepoConfig {
   branch?: string;
 }
 
-export type SecretsBackendType = '1password';
+export type KnownSecretsBackendType = '1password';
+export type SecretsBackendType = KnownSecretsBackendType | (string & {});
 
 export interface SecretsBackendDocuments {
   authJson?: string;
@@ -82,7 +83,13 @@ export function normalizeSecretsBackend(
   input: SyncConfig['secretsBackend']
 ): SecretsBackendConfig | undefined {
   if (!input || typeof input !== 'object') return undefined;
-  if (input.type !== '1password') return undefined;
+
+  const type = typeof input.type === 'string' ? input.type : undefined;
+  if (!type) return undefined;
+
+  if (type !== '1password') {
+    return { type };
+  }
 
   const vault = typeof input.vault === 'string' ? input.vault : undefined;
   const documentsInput = isPlainObject(input.documents) ? input.documents : {};

--- a/src/sync/config.ts
+++ b/src/sync/config.ts
@@ -113,7 +113,7 @@ export function canCommitMcpSecrets(config: SyncConfig): boolean {
   return Boolean(config.includeSecrets) && Boolean(config.includeMcpSecrets);
 }
 
-export function isOnePasswordBackend(config: SyncConfig): boolean {
+export function isOnePasswordBackend(config: NormalizedSyncConfig): boolean {
   return config.secretsBackend?.type === '1password';
 }
 

--- a/src/sync/paths.test.ts
+++ b/src/sync/paths.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { SyncConfig } from './config.js';
+import { normalizeSyncConfig } from './config.js';
 import { buildSyncPlan, resolveSyncLocations, resolveXdgPaths } from './paths.js';
 
 describe('resolveXdgPaths', () => {
@@ -50,7 +51,7 @@ describe('buildSyncPlan', () => {
       extraConfigPaths: ['/home/test/.config/opencode/custom.json'],
     };
 
-    const plan = buildSyncPlan(config, locations, '/repo', 'linux');
+    const plan = buildSyncPlan(normalizeSyncConfig(config), locations, '/repo', 'linux');
     const secretItems = plan.items.filter((item) => item.isSecret);
 
     expect(secretItems.length).toBe(0);
@@ -68,7 +69,7 @@ describe('buildSyncPlan', () => {
       extraConfigPaths: ['/home/test/.config/opencode/custom.json'],
     };
 
-    const plan = buildSyncPlan(config, locations, '/repo', 'linux');
+    const plan = buildSyncPlan(normalizeSyncConfig(config), locations, '/repo', 'linux');
     const secretItems = plan.items.filter((item) => item.isSecret);
 
     expect(secretItems.length).toBe(2);
@@ -84,7 +85,7 @@ describe('buildSyncPlan', () => {
       includeSecrets: false,
     };
 
-    const plan = buildSyncPlan(config, locations, '/repo', 'linux');
+    const plan = buildSyncPlan(normalizeSyncConfig(config), locations, '/repo', 'linux');
     const favoritesItem = plan.items.find((item) =>
       item.localPath.endsWith('/.local/state/opencode/model.json')
     );
@@ -92,7 +93,7 @@ describe('buildSyncPlan', () => {
     expect(favoritesItem).toBeTruthy();
 
     const disabledPlan = buildSyncPlan(
-      { ...config, includeModelFavorites: false },
+      normalizeSyncConfig({ ...config, includeModelFavorites: false }),
       locations,
       '/repo',
       'linux'

--- a/src/sync/paths.test.ts
+++ b/src/sync/paths.test.ts
@@ -59,6 +59,34 @@ describe('buildSyncPlan', () => {
     expect(plan.extraConfigs.allowlist.length).toBe(1);
   });
 
+  it('includes opencode-synced config file in items', () => {
+    const env = { HOME: '/home/test' } as NodeJS.ProcessEnv;
+    const locations = resolveSyncLocations(env, 'linux');
+    const config: SyncConfig = {
+      repo: { owner: 'acme', name: 'config' },
+      includeSecrets: false,
+    };
+
+    const plan = buildSyncPlan(normalizeSyncConfig(config), locations, '/repo', 'linux');
+    const syncItem = plan.items.find((item) => item.localPath === locations.syncConfigPath);
+
+    expect(syncItem).toBeTruthy();
+  });
+
+  it('filters sync config from extra config paths', () => {
+    const env = { HOME: '/home/test' } as NodeJS.ProcessEnv;
+    const locations = resolveSyncLocations(env, 'linux');
+    const config: SyncConfig = {
+      repo: { owner: 'acme', name: 'config' },
+      includeSecrets: false,
+      extraConfigPaths: [locations.syncConfigPath],
+    };
+
+    const plan = buildSyncPlan(normalizeSyncConfig(config), locations, '/repo', 'linux');
+
+    expect(plan.extraConfigs.allowlist.length).toBe(0);
+  });
+
   it('includes secrets when includeSecrets is true', () => {
     const env = { HOME: '/home/test' } as NodeJS.ProcessEnv;
     const locations = resolveSyncLocations(env, 'linux');

--- a/src/sync/paths.ts
+++ b/src/sync/paths.ts
@@ -1,7 +1,6 @@
 import crypto from 'node:crypto';
 import path from 'node:path';
-
-import type { SyncConfig } from './config.js';
+import type { NormalizedSyncConfig, SyncConfig } from './config.js';
 
 export interface XdgPaths {
   homeDir: string;
@@ -167,7 +166,7 @@ export function resolveRepoRoot(config: SyncConfig | null, locations: SyncLocati
 }
 
 export function buildSyncPlan(
-  config: SyncConfig,
+  config: NormalizedSyncConfig,
   locations: SyncLocations,
   repoRoot: string,
   platform: NodeJS.Platform = process.platform
@@ -185,6 +184,8 @@ export function buildSyncPlan(
   const configManifestPath = path.join(repoConfigRoot, 'extra-manifest.json');
 
   const items: SyncItem[] = [];
+  const authJsonPath = path.join(dataRoot, 'auth.json');
+  const mcpAuthJsonPath = path.join(dataRoot, 'mcp-auth.json');
 
   const addFile = (name: string, isSecret: boolean, isConfigFile: boolean): void => {
     items.push({
@@ -223,14 +224,14 @@ export function buildSyncPlan(
   if (config.includeSecrets) {
     items.push(
       {
-        localPath: path.join(dataRoot, 'auth.json'),
+        localPath: authJsonPath,
         repoPath: path.join(repoDataRoot, 'auth.json'),
         type: 'file',
         isSecret: true,
         isConfigFile: false,
       },
       {
-        localPath: path.join(dataRoot, 'mcp-auth.json'),
+        localPath: mcpAuthJsonPath,
         repoPath: path.join(repoDataRoot, 'mcp-auth.json'),
         type: 'file',
         isSecret: true,

--- a/src/sync/paths.ts
+++ b/src/sync/paths.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 import path from 'node:path';
 import type { NormalizedSyncConfig, SyncConfig } from './config.js';
-import { isOnePasswordBackend } from './config.js';
+import { hasSecretsBackend } from './config.js';
 
 export interface XdgPaths {
   homeDir: string;
@@ -185,7 +185,7 @@ export function buildSyncPlan(
   const configManifestPath = path.join(repoConfigRoot, 'extra-manifest.json');
 
   const items: SyncItem[] = [];
-  const usingOnePasswordBackend = isOnePasswordBackend(config);
+  const usingSecretsBackend = hasSecretsBackend(config);
   const authJsonPath = path.join(dataRoot, 'auth.json');
   const mcpAuthJsonPath = path.join(dataRoot, 'mcp-auth.json');
 
@@ -225,7 +225,7 @@ export function buildSyncPlan(
   }
 
   if (config.includeSecrets) {
-    if (!usingOnePasswordBackend) {
+    if (!usingSecretsBackend) {
       items.push(
         {
           localPath: authJsonPath,
@@ -270,7 +270,7 @@ export function buildSyncPlan(
   }
 
   const extraSecretPaths = config.includeSecrets ? config.extraSecretPaths : [];
-  const filteredExtraSecrets = usingOnePasswordBackend
+  const filteredExtraSecrets = usingSecretsBackend
     ? extraSecretPaths.filter(
         (entry) =>
           !isSamePath(entry, authJsonPath, locations.xdg.homeDir, platform) &&

--- a/src/sync/paths.ts
+++ b/src/sync/paths.ts
@@ -202,6 +202,7 @@ export function buildSyncPlan(
   addFile(DEFAULT_CONFIG_NAME, false, true);
   addFile(DEFAULT_CONFIGC_NAME, false, true);
   addFile(DEFAULT_AGENTS_NAME, false, false);
+  addFile(DEFAULT_SYNC_CONFIG_NAME, false, false);
 
   for (const dirName of CONFIG_DIRS) {
     items.push({
@@ -285,8 +286,12 @@ export function buildSyncPlan(
     platform
   );
 
+  const extraConfigPaths = (config.extraConfigPaths ?? []).filter(
+    (entry) => !isSamePath(entry, locations.syncConfigPath, locations.xdg.homeDir, platform)
+  );
+
   const extraConfigs = buildExtraPathPlan(
-    config.extraConfigPaths,
+    extraConfigPaths,
     locations,
     repoConfigExtraDir,
     configManifestPath,

--- a/src/sync/secrets-backend.test.ts
+++ b/src/sync/secrets-backend.test.ts
@@ -14,6 +14,21 @@ describe('resolveSecretsBackendConfig', () => {
     expect(resolution.state).toBe('none');
   });
 
+  it('rejects unsupported backend types', () => {
+    const resolution = resolveSecretsBackendConfig(
+      normalizeSyncConfig({
+        secretsBackend: {
+          type: 'vaultpass',
+        },
+      })
+    );
+
+    expect(resolution.state).toBe('invalid');
+    if (resolution.state === 'invalid') {
+      expect(resolution.error).toContain('Unsupported');
+    }
+  });
+
   it('validates required vault', () => {
     const resolution = resolveSecretsBackendConfig(
       normalizeSyncConfig({

--- a/src/sync/secrets-backend.test.ts
+++ b/src/sync/secrets-backend.test.ts
@@ -1,0 +1,108 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { normalizeSyncConfig } from './config.js';
+import { resolveSyncLocations } from './paths.js';
+import { computeSecretsHash, resolveSecretsBackendConfig } from './secrets-backend.js';
+
+describe('resolveSecretsBackendConfig', () => {
+  it('returns none when backend is missing', () => {
+    const resolution = resolveSecretsBackendConfig(normalizeSyncConfig({}));
+    expect(resolution.state).toBe('none');
+  });
+
+  it('validates required vault', () => {
+    const resolution = resolveSecretsBackendConfig(
+      normalizeSyncConfig({
+        secretsBackend: {
+          type: '1password',
+          documents: {
+            authJson: 'opencode-auth.json',
+            mcpAuthJson: 'opencode-mcp-auth.json',
+          },
+        },
+      })
+    );
+
+    expect(resolution.state).toBe('invalid');
+    if (resolution.state === 'invalid') {
+      expect(resolution.error).toContain('vault');
+    }
+  });
+
+  it('requires unique document names', () => {
+    const resolution = resolveSecretsBackendConfig(
+      normalizeSyncConfig({
+        secretsBackend: {
+          type: '1password',
+          vault: 'Personal',
+          documents: {
+            authJson: 'shared.json',
+            mcpAuthJson: 'SHARED.json',
+          },
+        },
+      })
+    );
+
+    expect(resolution.state).toBe('invalid');
+    if (resolution.state === 'invalid') {
+      expect(resolution.error).toContain('unique');
+    }
+  });
+
+  it('returns ok when valid', () => {
+    const resolution = resolveSecretsBackendConfig(
+      normalizeSyncConfig({
+        secretsBackend: {
+          type: '1password',
+          vault: 'Personal',
+          documents: {
+            authJson: 'opencode-auth.json',
+            mcpAuthJson: 'opencode-mcp-auth.json',
+          },
+        },
+      })
+    );
+
+    expect(resolution.state).toBe('ok');
+    if (resolution.state === 'ok') {
+      expect(resolution.config.vault).toBe('Personal');
+      expect(resolution.config.authJson).toBe('opencode-auth.json');
+    }
+  });
+});
+
+describe('computeSecretsHash', () => {
+  it('changes when auth files change', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'opencode-sync-'));
+    const env = {
+      HOME: root,
+      XDG_DATA_HOME: path.join(root, 'data'),
+      XDG_CONFIG_HOME: path.join(root, 'config'),
+      XDG_STATE_HOME: path.join(root, 'state'),
+    } as NodeJS.ProcessEnv;
+
+    try {
+      const locations = resolveSyncLocations(env, 'linux');
+      const dataRoot = path.join(locations.xdg.dataDir, 'opencode');
+      const authPath = path.join(dataRoot, 'auth.json');
+      const mcpPath = path.join(dataRoot, 'mcp-auth.json');
+
+      await mkdir(dataRoot, { recursive: true });
+
+      const emptyHash = await computeSecretsHash(locations);
+      await writeFile(authPath, 'first');
+      const authHash = await computeSecretsHash(locations);
+      await writeFile(mcpPath, 'second');
+      const bothHash = await computeSecretsHash(locations);
+
+      expect(emptyHash).not.toBe(authHash);
+      expect(authHash).not.toBe(bothHash);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/sync/secrets-backend.ts
+++ b/src/sync/secrets-backend.ts
@@ -1,0 +1,241 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { PluginInput } from '@opencode-ai/plugin';
+import type { SecretsBackendConfig, SyncConfig } from './config.js';
+import { chmodIfExists, pathExists } from './config.js';
+import { SyncCommandError } from './errors.js';
+import type { SyncLocations } from './paths.js';
+
+type Shell = PluginInput['$'];
+
+export interface OnePasswordConfig {
+  vault: string;
+  documents: Required<Pick<SecretsBackendConfig, 'documents'>>['documents'] & {
+    authJson: string;
+    mcpAuthJson: string;
+  };
+}
+
+export interface SecretsBackend {
+  pull: () => Promise<void>;
+  push: () => Promise<void>;
+  status: () => Promise<string>;
+}
+
+export type OnePasswordResolution =
+  | { state: 'none' }
+  | { state: 'invalid'; error: string }
+  | { state: 'ok'; config: OnePasswordConfig };
+
+export function resolveOnePasswordConfig(config: SyncConfig): OnePasswordResolution {
+  const backend = config.secretsBackend;
+  if (!backend || backend.type !== '1password') {
+    return { state: 'none' };
+  }
+
+  const vault = backend.vault?.trim();
+  if (!vault) {
+    return {
+      state: 'invalid',
+      error: 'secretsBackend.vault is required for type "1password".',
+    };
+  }
+
+  const documents = backend.documents ?? {};
+  const authJson = documents.authJson?.trim();
+  const mcpAuthJson = documents.mcpAuthJson?.trim();
+
+  if (!authJson || !mcpAuthJson) {
+    return {
+      state: 'invalid',
+      error:
+        'secretsBackend.documents.authJson and secretsBackend.documents.mcpAuthJson ' +
+        'are required for type "1password".',
+    };
+  }
+
+  return {
+    state: 'ok',
+    config: {
+      vault,
+      documents: {
+        authJson,
+        mcpAuthJson,
+        envFile: documents.envFile,
+      },
+    },
+  };
+}
+
+export function resolveAuthFilePaths(locations: SyncLocations): {
+  authPath: string;
+  mcpAuthPath: string;
+} {
+  const dataRoot = path.join(locations.xdg.dataDir, 'opencode');
+  return {
+    authPath: path.join(dataRoot, 'auth.json'),
+    mcpAuthPath: path.join(dataRoot, 'mcp-auth.json'),
+  };
+}
+
+export function resolveRepoAuthPaths(repoRoot: string): {
+  authRepoPath: string;
+  mcpAuthRepoPath: string;
+} {
+  const repoDataRoot = path.join(repoRoot, 'data');
+  return {
+    authRepoPath: path.join(repoDataRoot, 'auth.json'),
+    mcpAuthRepoPath: path.join(repoDataRoot, 'mcp-auth.json'),
+  };
+}
+
+export function createOnePasswordBackend(options: {
+  $: Shell;
+  locations: SyncLocations;
+  config: OnePasswordConfig;
+}): SecretsBackend {
+  const { $, locations, config } = options;
+  const { authPath, mcpAuthPath } = resolveAuthFilePaths(locations);
+
+  const pull = async (): Promise<void> => {
+    await ensureOpAvailable($);
+    await pullDocument($, config.vault, config.documents.authJson, authPath);
+    await pullDocument($, config.vault, config.documents.mcpAuthJson, mcpAuthPath);
+  };
+
+  const push = async (): Promise<void> => {
+    await ensureOpAvailable($);
+    await pushDocument($, config.vault, config.documents.authJson, authPath);
+    await pushDocument($, config.vault, config.documents.mcpAuthJson, mcpAuthPath);
+  };
+
+  const status = async (): Promise<string> => {
+    await ensureOpAvailable($);
+    return `1Password backend configured for vault "${config.vault}".`;
+  };
+
+  return { pull, push, status };
+}
+
+async function ensureOpAvailable($: Shell): Promise<void> {
+  try {
+    await $`op --version`.quiet();
+  } catch {
+    throw new SyncCommandError('1Password CLI not found. Install it and sign in with `op signin`.');
+  }
+}
+
+async function pullDocument(
+  $: Shell,
+  vault: string,
+  documentName: string,
+  targetPath: string
+): Promise<void> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'opencode-synced-'));
+  const tempPath = path.join(tempDir, path.basename(targetPath));
+
+  try {
+    const result = await opDocumentGet($, vault, documentName, tempPath);
+    if (result === 'not_found') {
+      return;
+    }
+    await replaceFile(tempPath, targetPath);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function pushDocument(
+  $: Shell,
+  vault: string,
+  documentName: string,
+  sourcePath: string
+): Promise<void> {
+  if (!(await pathExists(sourcePath))) {
+    return;
+  }
+
+  try {
+    await opDocumentEdit($, vault, documentName, sourcePath);
+  } catch (error) {
+    if (!isNotFoundError(error)) {
+      throw new SyncCommandError(`1Password update failed: ${formatShellError(error)}`);
+    }
+    try {
+      await opDocumentCreate($, vault, documentName, sourcePath);
+    } catch (createError) {
+      throw new SyncCommandError(`1Password create failed: ${formatShellError(createError)}`);
+    }
+  }
+}
+
+async function opDocumentGet(
+  $: Shell,
+  vault: string,
+  name: string,
+  outFile: string
+): Promise<'ok' | 'not_found'> {
+  try {
+    await $`op document get ${name} --vault ${vault} --out-file ${outFile}`.quiet();
+    return 'ok';
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return 'not_found';
+    }
+    throw new SyncCommandError(`1Password download failed: ${formatShellError(error)}`);
+  }
+}
+
+async function opDocumentCreate(
+  $: Shell,
+  vault: string,
+  name: string,
+  sourcePath: string
+): Promise<void> {
+  await $`op document create --vault ${vault} ${sourcePath} --title ${name}`.quiet();
+}
+
+async function opDocumentEdit(
+  $: Shell,
+  vault: string,
+  name: string,
+  sourcePath: string
+): Promise<void> {
+  await $`op document edit ${name} --vault ${vault} ${sourcePath}`.quiet();
+}
+
+async function replaceFile(sourcePath: string, targetPath: string): Promise<void> {
+  await fs.mkdir(path.dirname(targetPath), { recursive: true });
+  try {
+    await fs.rename(sourcePath, targetPath);
+  } catch (error) {
+    const maybeErrno = error as NodeJS.ErrnoException;
+    if (maybeErrno.code !== 'EXDEV') {
+      throw error;
+    }
+    await fs.copyFile(sourcePath, targetPath);
+    await fs.unlink(sourcePath);
+  }
+  await chmodIfExists(targetPath, 0o600);
+}
+
+function isNotFoundError(error: unknown): boolean {
+  const text = formatShellError(error);
+  return /not found/i.test(text);
+}
+
+function formatShellError(error: unknown): string {
+  if (!error) return 'Unknown error';
+  if (typeof error === 'string') return error;
+  if (error instanceof Error && error.message) return error.message;
+
+  const maybe = error as { stderr?: string; message?: string };
+  const parts = [maybe.stderr, maybe.message].filter(
+    (value): value is string => typeof value === 'string' && value.length > 0
+  );
+  if (parts.length > 0) return parts.join('\n');
+
+  return String(error);
+}

--- a/src/sync/secrets-backend.ts
+++ b/src/sync/secrets-backend.ts
@@ -1,9 +1,9 @@
+import crypto from 'node:crypto';
 import { promises as fs } from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
 import type { PluginInput } from '@opencode-ai/plugin';
-import type { NormalizedSyncConfig } from './config.js';
+import type { NormalizedSyncConfig, SecretsBackendConfig } from './config.js';
 import { chmodIfExists, pathExists } from './config.js';
 import { SyncCommandError } from './errors.js';
 import type { SyncLocations } from './paths.js';
@@ -11,12 +11,10 @@ import type { SyncLocations } from './paths.js';
 type Shell = PluginInput['$'];
 
 export interface OnePasswordConfig {
+  type: '1password';
   vault: string;
-  documents: {
-    authJson: string;
-    mcpAuthJson: string;
-    envFile?: string;
-  };
+  authJson: string;
+  mcpAuthJson: string;
 }
 
 export interface SecretsBackend {
@@ -25,49 +23,33 @@ export interface SecretsBackend {
   status: () => Promise<string>;
 }
 
-export type OnePasswordResolution =
+export type SecretsBackendResolution =
   | { state: 'none' }
   | { state: 'invalid'; error: string }
   | { state: 'ok'; config: OnePasswordConfig };
 
-export function resolveOnePasswordConfig(config: NormalizedSyncConfig): OnePasswordResolution {
+type DocumentIndex = Map<string, VaultDocumentEntry[]>;
+
+interface VaultDocumentEntry {
+  id: string;
+  title: string;
+}
+
+export function resolveSecretsBackendConfig(
+  config: NormalizedSyncConfig
+): SecretsBackendResolution {
   const backend = config.secretsBackend;
-  if (!backend || backend.type !== '1password') {
+  if (!backend) {
     return { state: 'none' };
   }
-
-  const vault = backend.vault?.trim();
-  if (!vault) {
+  const backendType = backend.type as string;
+  if (backendType !== '1password') {
     return {
       state: 'invalid',
-      error: 'secretsBackend.vault is required for type "1password".',
+      error: `Unsupported secrets backend type "${backendType}".`,
     };
   }
-
-  const documents = backend.documents ?? {};
-  const authJson = documents.authJson?.trim();
-  const mcpAuthJson = documents.mcpAuthJson?.trim();
-
-  if (!authJson || !mcpAuthJson) {
-    return {
-      state: 'invalid',
-      error:
-        'secretsBackend.documents.authJson and secretsBackend.documents.mcpAuthJson ' +
-        'are required for type "1password".',
-    };
-  }
-
-  return {
-    state: 'ok',
-    config: {
-      vault,
-      documents: {
-        authJson,
-        mcpAuthJson,
-        envFile: documents.envFile,
-      },
-    },
-  };
+  return resolveOnePasswordConfig(backend);
 }
 
 export function resolveAuthFilePaths(locations: SyncLocations): {
@@ -92,7 +74,69 @@ export function resolveRepoAuthPaths(repoRoot: string): {
   };
 }
 
-export function createOnePasswordBackend(options: {
+export async function computeSecretsHash(locations: SyncLocations): Promise<string> {
+  const { authPath, mcpAuthPath } = resolveAuthFilePaths(locations);
+  return await hashFiles([authPath, mcpAuthPath]);
+}
+
+export function createSecretsBackend(options: {
+  $: Shell;
+  locations: SyncLocations;
+  config: OnePasswordConfig;
+}): SecretsBackend {
+  const backendType = options.config.type as string;
+  if (backendType === '1password') {
+    return createOnePasswordBackend(options);
+  }
+  throw new SyncCommandError(`Unsupported secrets backend type "${backendType}".`);
+}
+
+function resolveOnePasswordConfig(backend: SecretsBackendConfig): SecretsBackendResolution {
+  const vault = backend.vault?.trim();
+  if (!vault) {
+    return {
+      state: 'invalid',
+      error: 'secretsBackend.vault is required for type "1password".',
+    };
+  }
+
+  const documents = backend.documents ?? {};
+  const authJson = documents.authJson?.trim();
+  const mcpAuthJson = documents.mcpAuthJson?.trim();
+
+  if (!authJson || !mcpAuthJson) {
+    return {
+      state: 'invalid',
+      error:
+        'secretsBackend.documents.authJson and secretsBackend.documents.mcpAuthJson ' +
+        'are required for type "1password".',
+    };
+  }
+
+  if (normalizeDocumentName(authJson) === normalizeDocumentName(mcpAuthJson)) {
+    return {
+      state: 'invalid',
+      error:
+        'secretsBackend.documents.authJson and secretsBackend.documents.mcpAuthJson must be unique.',
+    };
+  }
+
+  return {
+    state: 'ok',
+    config: {
+      type: '1password',
+      vault,
+      authJson,
+      mcpAuthJson,
+    },
+  };
+}
+
+function normalizeDocumentName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+function createOnePasswordBackend(options: {
   $: Shell;
   locations: SyncLocations;
   config: OnePasswordConfig;
@@ -102,14 +146,20 @@ export function createOnePasswordBackend(options: {
 
   const pull = async (): Promise<void> => {
     await ensureOpAvailable($);
-    await pullDocument($, config.vault, config.documents.authJson, authPath);
-    await pullDocument($, config.vault, config.documents.mcpAuthJson, mcpAuthPath);
+    const index = await listVaultDocuments($, config.vault);
+    await pullDocument($, config.vault, config.authJson, authPath, index);
+    await pullDocument($, config.vault, config.mcpAuthJson, mcpAuthPath, index);
   };
 
   const push = async (): Promise<void> => {
     await ensureOpAvailable($);
-    await pushDocument($, config.vault, config.documents.authJson, authPath);
-    await pushDocument($, config.vault, config.documents.mcpAuthJson, mcpAuthPath);
+    const existing = await Promise.all([pathExists(authPath), pathExists(mcpAuthPath)]);
+    if (!existing.some(Boolean)) {
+      return;
+    }
+    const index = await listVaultDocuments($, config.vault);
+    await pushDocument($, config.vault, config.authJson, authPath, index);
+    await pushDocument($, config.vault, config.mcpAuthJson, mcpAuthPath, index);
   };
 
   const status = async (): Promise<string> => {
@@ -128,20 +178,86 @@ async function ensureOpAvailable($: Shell): Promise<void> {
   }
 }
 
+async function listVaultDocuments($: Shell, vault: string): Promise<DocumentIndex> {
+  let output: string;
+  try {
+    output = await $`op item list --vault ${vault} --categories Document --format json`
+      .quiet()
+      .text();
+  } catch (error) {
+    throw new SyncCommandError(`1Password document list failed: ${formatShellError(error)}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output) as unknown;
+  } catch {
+    throw new SyncCommandError('1Password document list returned invalid JSON.');
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new SyncCommandError('1Password document list returned unexpected data.');
+  }
+
+  const index: DocumentIndex = new Map();
+  for (const entry of parsed) {
+    if (!entry || typeof entry !== 'object') continue;
+    const record = entry as { id?: unknown; title?: unknown };
+    const id = typeof record.id === 'string' ? record.id : '';
+    const title = typeof record.title === 'string' ? record.title : '';
+    if (!id || !title) continue;
+    const key = normalizeDocumentName(title);
+    const existing = index.get(key);
+    const item = { id, title };
+    if (existing) {
+      existing.push(item);
+    } else {
+      index.set(key, [item]);
+    }
+  }
+
+  return index;
+}
+
+function lookupDocument(
+  index: DocumentIndex,
+  documentName: string
+): {
+  state: 'missing' | 'duplicate' | 'ok';
+  count: number;
+} {
+  const key = normalizeDocumentName(documentName);
+  const matches = index.get(key) ?? [];
+  if (matches.length === 0) {
+    return { state: 'missing', count: 0 };
+  }
+  if (matches.length > 1) {
+    return { state: 'duplicate', count: matches.length };
+  }
+  return { state: 'ok', count: 1 };
+}
+
 async function pullDocument(
   $: Shell,
   vault: string,
   documentName: string,
-  targetPath: string
+  targetPath: string,
+  index: DocumentIndex
 ): Promise<void> {
-  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'opencode-synced-'));
-  const tempPath = path.join(tempDir, path.basename(targetPath));
+  const lookup = lookupDocument(index, documentName);
+  if (lookup.state === 'missing') {
+    return;
+  }
+  if (lookup.state === 'duplicate') {
+    throw new SyncCommandError(
+      `Multiple documents named "${documentName}" found in vault "${vault}". ` +
+        'Rename them to be unique.'
+    );
+  }
 
+  const { tempDir, tempPath } = await createTempPath(targetPath);
   try {
-    const result = await opDocumentGet($, vault, documentName, tempPath);
-    if (result === 'not_found') {
-      return;
-    }
+    await opDocumentGet($, vault, documentName, tempPath);
     await replaceFile(tempPath, targetPath);
   } finally {
     await fs.rm(tempDir, { recursive: true, force: true });
@@ -152,23 +268,34 @@ async function pushDocument(
   $: Shell,
   vault: string,
   documentName: string,
-  sourcePath: string
+  sourcePath: string,
+  index: DocumentIndex
 ): Promise<void> {
   if (!(await pathExists(sourcePath))) {
+    return;
+  }
+
+  const lookup = lookupDocument(index, documentName);
+  if (lookup.state === 'duplicate') {
+    throw new SyncCommandError(
+      `Multiple documents named "${documentName}" found in vault "${vault}". ` +
+        'Rename them to be unique.'
+    );
+  }
+
+  if (lookup.state === 'missing') {
+    try {
+      await opDocumentCreate($, vault, documentName, sourcePath);
+    } catch (createError) {
+      throw new SyncCommandError(`1Password create failed: ${formatShellError(createError)}`);
+    }
     return;
   }
 
   try {
     await opDocumentEdit($, vault, documentName, sourcePath);
   } catch (error) {
-    if (!isNotFoundError(error)) {
-      throw new SyncCommandError(`1Password update failed: ${formatShellError(error)}`);
-    }
-    try {
-      await opDocumentCreate($, vault, documentName, sourcePath);
-    } catch (createError) {
-      throw new SyncCommandError(`1Password create failed: ${formatShellError(createError)}`);
-    }
+    throw new SyncCommandError(`1Password update failed: ${formatShellError(error)}`);
   }
 }
 
@@ -177,14 +304,10 @@ async function opDocumentGet(
   vault: string,
   name: string,
   outFile: string
-): Promise<'ok' | 'not_found'> {
+): Promise<void> {
   try {
     await $`op document get ${name} --vault ${vault} --out-file ${outFile}`.quiet();
-    return 'ok';
   } catch (error) {
-    if (isNotFoundError(error)) {
-      return 'not_found';
-    }
     throw new SyncCommandError(`1Password download failed: ${formatShellError(error)}`);
   }
 }
@@ -207,6 +330,14 @@ async function opDocumentEdit(
   await $`op document edit ${name} --vault ${vault} ${sourcePath}`.quiet();
 }
 
+async function createTempPath(targetPath: string): Promise<{ tempDir: string; tempPath: string }> {
+  const targetDir = path.dirname(targetPath);
+  await fs.mkdir(targetDir, { recursive: true });
+  const tempDir = await fs.mkdtemp(path.join(targetDir, '.opencode-synced-'));
+  const tempPath = path.join(tempDir, path.basename(targetPath));
+  return { tempDir, tempPath };
+}
+
 async function replaceFile(sourcePath: string, targetPath: string): Promise<void> {
   await fs.mkdir(path.dirname(targetPath), { recursive: true });
   await chmodIfExists(sourcePath, 0o600);
@@ -223,9 +354,20 @@ async function replaceFile(sourcePath: string, targetPath: string): Promise<void
   await chmodIfExists(targetPath, 0o600);
 }
 
-function isNotFoundError(error: unknown): boolean {
-  const text = formatShellError(error);
-  return /not found/i.test(text);
+async function hashFiles(paths: string[]): Promise<string> {
+  const hash = crypto.createHash('sha256');
+  for (const filePath of paths) {
+    hash.update(filePath);
+    hash.update('\0');
+    const exists = await pathExists(filePath);
+    hash.update(exists ? '1' : '0');
+    if (exists) {
+      const data = await fs.readFile(filePath);
+      hash.update(data);
+    }
+    hash.update('\0');
+  }
+  return hash.digest('hex');
 }
 
 function formatShellError(error: unknown): string {

--- a/src/sync/secrets-backend.ts
+++ b/src/sync/secrets-backend.ts
@@ -262,10 +262,7 @@ async function pullDocument(
     } catch (error) {
       const retryLookup = await lookupDocumentWithRetry($, vault, documentName);
       if (!retryLookup) {
-        if (error instanceof SyncCommandError) {
-          throw error;
-        }
-        throw new SyncCommandError(`1Password download failed: ${formatShellError(error)}`);
+        throw error;
       }
       if (retryLookup.state === 'missing') {
         return;
@@ -276,10 +273,7 @@ async function pullDocument(
             'Rename them to be unique.'
         );
       }
-      if (error instanceof SyncCommandError) {
-        throw error;
-      }
-      throw new SyncCommandError(`1Password download failed: ${formatShellError(error)}`);
+      throw error;
     }
     await replaceFile(tempPath, targetPath);
   } finally {
@@ -320,10 +314,7 @@ async function pushDocument(
   } catch (error) {
     const retryLookup = await lookupDocumentWithRetry($, vault, documentName);
     if (!retryLookup) {
-      if (error instanceof SyncCommandError) {
-        throw error;
-      }
-      throw new SyncCommandError(`1Password update failed: ${formatShellError(error)}`);
+      throw error;
     }
     if (retryLookup.state === 'missing') {
       try {
@@ -339,10 +330,7 @@ async function pushDocument(
           'Rename them to be unique.'
       );
     }
-    if (error instanceof SyncCommandError) {
-      throw error;
-    }
-    throw new SyncCommandError(`1Password update failed: ${formatShellError(error)}`);
+    throw error;
   }
 }
 
@@ -374,7 +362,11 @@ async function opDocumentEdit(
   name: string,
   sourcePath: string
 ): Promise<void> {
-  await $`op document edit ${name} --vault ${vault} ${sourcePath}`.quiet();
+  try {
+    await $`op document edit ${name} --vault ${vault} ${sourcePath}`.quiet();
+  } catch (error) {
+    throw new SyncCommandError(`1Password update failed: ${formatShellError(error)}`);
+  }
 }
 
 async function lookupDocumentWithRetry(


### PR DESCRIPTION
## Summary
- add a 1Password secrets backend with config validation and backend plumbing
- integrate secrets pull/push/status commands and hook backend into sync lifecycle
- exclude auth.json and mcp-auth.json from git sync when using 1Password

## Testing
- Not run (not requested)

## Related
- Addresses #34