### PR TITLE
feat: update release workflow to maintain latest tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,18 @@ jobs:
           release-type: node
           skip-github-pull-request: false
 
+      - name: Checkout
+        if: ${{ steps.release-please.outputs.releases_created }}
+        uses: actions/checkout@v4
+
+      - name: Update latest tag
+        if: ${{ steps.release-please.outputs.releases_created }}
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git tag -f latest
+          git push origin latest
+
   dispatch-publish:
     needs: process
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updates the release workflow to automatically set the 'latest' tag to the newly created release tag. This ensures users can pull the latest release using the 'latest' tag.

---
*PR created automatically by Jules for task [8491389348983802807](https://jules.google.com/task/8491389348983802807) started by @iHildy*