### PR TITLE
fix: support XDG paths on Windows for opencode compatibility

### DIFF
--- a/src/sync/paths.test.ts
+++ b/src/sync/paths.test.ts
@@ -23,6 +23,36 @@ describe('resolveXdgPaths', () => {
     expect(paths.configDir).toBe('C:\\Users\\Test\\AppData\\Roaming');
     expect(paths.dataDir).toBe('C:\\Users\\Test\\AppData\\Local');
   });
+
+  it('respects XDG env vars on windows', () => {
+    const env = {
+      USERPROFILE: 'C:\\Users\\Test',
+      APPDATA: 'C:\\Users\\Test\\AppData\\Roaming',
+      LOCALAPPDATA: 'C:\\Users\\Test\\AppData\\Local',
+      XDG_CONFIG_HOME: 'C:\\Users\\Test\\.config',
+      XDG_DATA_HOME: 'C:\\Users\\Test\\.local\\share',
+      XDG_STATE_HOME: 'C:\\Users\\Test\\.local\\state',
+    } as NodeJS.ProcessEnv;
+    const paths = resolveXdgPaths(env, 'win32');
+
+    expect(paths.configDir).toBe('C:\\Users\\Test\\.config');
+    expect(paths.dataDir).toBe('C:\\Users\\Test\\.local\\share');
+    expect(paths.stateDir).toBe('C:\\Users\\Test\\.local\\state');
+  });
+
+  it('prefers XDG on windows when only XDG_CONFIG_HOME is set', () => {
+    const env = {
+      USERPROFILE: 'C:\\Users\\Test',
+      APPDATA: 'C:\\Users\\Test\\AppData\\Roaming',
+      LOCALAPPDATA: 'C:\\Users\\Test\\AppData\\Local',
+      XDG_CONFIG_HOME: 'C:\\Users\\Test\\.config',
+    } as NodeJS.ProcessEnv;
+    const paths = resolveXdgPaths(env, 'win32');
+
+    expect(paths.configDir).toBe('C:\\Users\\Test\\.config');
+    expect(paths.dataDir).toBe('C:\\Users\\Test\\.local\\share');
+    expect(paths.stateDir).toBe('C:\\Users\\Test\\.local\\state');
+  });
 });
 
 describe('resolveSyncLocations', () => {


### PR DESCRIPTION
## Summary

- On Windows, opencode uses XDG-style paths (~/.config, ~/.local/share, ~/.local/state) instead of standard AppData paths
- The sync plugin only checks AppData paths on Windows, causing it to miss config, sessions, secrets, and state data
- This fix adds XDG path detection to `resolveXdgPaths()` on win32

## Changes

**`src/sync/paths.ts`** - Modified `resolveXdgPaths()` to:
1. Honor `XDG_CONFIG_HOME`/`XDG_DATA_HOME`/`XDG_STATE_HOME` env vars on Windows when explicitly set
2. Auto-detect XDG layout by checking for `~/.config/opencode` directory existence
3. Fall back to standard Windows AppData paths only if neither condition applies

**`src/sync/paths.test.ts`** - Added two test cases:
- Verifies XDG env vars are respected on win32
- Verifies partial XDG env var sets trigger XDG path resolution

## Behavior

- **No breaking change**: Systems using standard AppData paths continue to work
- **New**: Windows systems with XDG layout (like opencode's default) are now detected automatically
- **New**: Users can explicitly set XDG env vars to override path detection

## Testing

- Tested locally on Windows 11 with opencode using XDG paths
- Successfully synced config, sessions, secrets, prompt history, and model favorites after the fix
- All existing tests continue to pass (3 pre-existing failures due to running tests on Windows with path separator differences)