### PR TITLE
feat: sync modern opencode directories and portable extra paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage/
 .memory/
 opencode-plugin-template/
 opencode-docs-*/
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -89,8 +89,11 @@ Create `~/.config/opencode/opencode-synced.jsonc`:
 - `~/.config/opencode/opencode.json` and `opencode.jsonc`
 - `~/.config/opencode/AGENTS.md`
 - `~/.config/opencode/agent/`, `command/`, `mode/`, `tool/`, `themes/`, `plugin/`
+- `~/.config/opencode/agents/`, `instructions/`, `plugins/`, `skills/`, `superpowers/`
 - `~/.local/state/opencode/model.json` (model favorites)
 - Any extra paths in `extraConfigPaths` (allowlist, files or folders)
+
+Extra path manifests store home-relative `~` paths when possible to avoid Linux/macOS/WSL path churn.
 
 ### Secrets (private repos only)
 

--- a/src/sync/apply.test.ts
+++ b/src/sync/apply.test.ts
@@ -1,0 +1,166 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { syncRepoToLocal } from './apply.js';
+import type { SyncPlan } from './paths.js';
+import { normalizePath } from './paths.js';
+
+describe('syncRepoToLocal extra manifest repoPath validation', () => {
+  it('rejects absolute repoPath values from manifest', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'opencode-sync-apply-'));
+    try {
+      const homeDir = path.join(root, 'home');
+      const repoRoot = path.join(root, 'repo');
+      const localPath = path.join(homeDir, 'target.txt');
+      const manifestPath = path.join(repoRoot, 'config', 'extra-manifest.json');
+
+      await mkdir(path.dirname(manifestPath), { recursive: true });
+      await writeFile(
+        manifestPath,
+        JSON.stringify(
+          {
+            entries: [
+              {
+                sourcePath: localPath,
+                repoPath: '/etc/passwd',
+                type: 'file',
+              },
+            ],
+          },
+          null,
+          2
+        ),
+        'utf8'
+      );
+
+      const plan: SyncPlan = {
+        items: [],
+        extraConfigs: {
+          allowlist: [normalizePath(localPath, homeDir, 'linux')],
+          manifestPath,
+          entries: [],
+        },
+        extraSecrets: {
+          allowlist: [],
+          manifestPath: path.join(repoRoot, 'secrets', 'extra-manifest.json'),
+          entries: [],
+        },
+        repoRoot,
+        homeDir,
+        platform: 'linux',
+      };
+
+      await expect(syncRepoToLocal(plan, null)).rejects.toThrow(/absolute paths are not allowed/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects traversal repoPath values from manifest', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'opencode-sync-apply-'));
+    try {
+      const homeDir = path.join(root, 'home');
+      const repoRoot = path.join(root, 'repo');
+      const localPath = path.join(homeDir, 'target.txt');
+      const manifestPath = path.join(repoRoot, 'config', 'extra-manifest.json');
+
+      await mkdir(path.dirname(manifestPath), { recursive: true });
+      await writeFile(
+        manifestPath,
+        JSON.stringify(
+          {
+            entries: [
+              {
+                sourcePath: localPath,
+                repoPath: '../../etc/passwd',
+                type: 'file',
+              },
+            ],
+          },
+          null,
+          2
+        ),
+        'utf8'
+      );
+
+      const plan: SyncPlan = {
+        items: [],
+        extraConfigs: {
+          allowlist: [normalizePath(localPath, homeDir, 'linux')],
+          manifestPath,
+          entries: [],
+        },
+        extraSecrets: {
+          allowlist: [],
+          manifestPath: path.join(repoRoot, 'secrets', 'extra-manifest.json'),
+          entries: [],
+        },
+        repoRoot,
+        homeDir,
+        platform: 'linux',
+      };
+
+      await expect(syncRepoToLocal(plan, null)).rejects.toThrow(/path escapes repository root/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts safe relative repoPath values from manifest', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'opencode-sync-apply-'));
+    try {
+      const homeDir = path.join(root, 'home');
+      const repoRoot = path.join(root, 'repo');
+      const localPath = path.join(homeDir, 'target.txt');
+      const manifestPath = path.join(repoRoot, 'config', 'extra-manifest.json');
+      const repoSourcePath = path.join(repoRoot, 'config', 'extra', 'safe.txt');
+
+      await mkdir(path.dirname(manifestPath), { recursive: true });
+      await mkdir(path.dirname(repoSourcePath), { recursive: true });
+      await writeFile(repoSourcePath, 'safe-data\n', 'utf8');
+      await writeFile(
+        manifestPath,
+        JSON.stringify(
+          {
+            entries: [
+              {
+                sourcePath: localPath,
+                repoPath: 'config/extra/safe.txt',
+                type: 'file',
+              },
+            ],
+          },
+          null,
+          2
+        ),
+        'utf8'
+      );
+
+      const plan: SyncPlan = {
+        items: [],
+        extraConfigs: {
+          allowlist: [normalizePath(localPath, homeDir, 'linux')],
+          manifestPath,
+          entries: [],
+        },
+        extraSecrets: {
+          allowlist: [],
+          manifestPath: path.join(repoRoot, 'secrets', 'extra-manifest.json'),
+          entries: [],
+        },
+        repoRoot,
+        homeDir,
+        platform: 'linux',
+      };
+
+      await syncRepoToLocal(plan, null);
+
+      const output = await readFile(localPath, 'utf8');
+      expect(output).toBe('safe-data\n');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/sync/apply.ts
+++ b/src/sync/apply.ts
@@ -17,7 +17,7 @@ import {
   stripOverrideKeys,
 } from './mcp-secrets.js';
 import type { ExtraPathPlan, SyncItem, SyncPlan } from './paths.js';
-import { normalizePath } from './paths.js';
+import { expandHome, normalizePath } from './paths.js';
 
 type ExtraPathType = 'file' | 'dir';
 
@@ -241,7 +241,7 @@ async function applyExtraPaths(plan: SyncPlan, extra: ExtraPathPlan): Promise<vo
     const repoPath = path.isAbsolute(entry.repoPath)
       ? entry.repoPath
       : path.join(plan.repoRoot, entry.repoPath);
-    const localPath = entry.sourcePath;
+    const localPath = expandHome(entry.sourcePath, plan.homeDir);
     const entryType: ExtraPathType = entry.type ?? 'file';
 
     if (!(await pathExists(repoPath))) continue;

--- a/src/sync/paths.ts
+++ b/src/sync/paths.ts
@@ -51,7 +51,19 @@ const DEFAULT_SYNC_CONFIG_NAME = 'opencode-synced.jsonc';
 const DEFAULT_OVERRIDES_NAME = 'opencode-synced.overrides.jsonc';
 const DEFAULT_STATE_NAME = 'sync-state.json';
 
-const CONFIG_DIRS = ['agent', 'command', 'mode', 'tool', 'themes', 'plugin'];
+const CONFIG_DIRS = [
+  'agent',
+  'command',
+  'mode',
+  'tool',
+  'themes',
+  'plugin',
+  'agents',
+  'instructions',
+  'plugins',
+  'skills',
+  'superpowers',
+];
 const SESSION_DIRS = ['storage/session', 'storage/message', 'storage/part', 'storage/session_diff'];
 const PROMPT_STASH_FILES = ['prompt-stash.jsonl', 'prompt-history.jsonl'];
 const MODEL_FAVORITES_FILE = 'model.json';
@@ -154,6 +166,30 @@ export function encodeExtraPath(inputPath: string): string {
   const hash = crypto.createHash('sha1').update(normalized).digest('hex').slice(0, 8);
   const base = safeBase ? safeBase.slice(-80) : 'path';
   return `${base}-${hash}`;
+}
+
+export function toPortableSourcePath(
+  inputPath: string,
+  homeDir: string,
+  platform: NodeJS.Platform = process.platform
+): string {
+  if (!homeDir) {
+    return inputPath;
+  }
+
+  const normalizedInput = normalizePath(inputPath, homeDir, platform);
+  const normalizedHome = normalizePath(homeDir, homeDir, platform);
+  if (normalizedInput === normalizedHome) {
+    return '~';
+  }
+
+  const relativeToHome = path.relative(normalizedHome, normalizedInput);
+  const outsideHome = relativeToHome === '..' || relativeToHome.startsWith(`..${path.sep}`);
+  if (outsideHome || path.isAbsolute(relativeToHome)) {
+    return normalizedInput;
+  }
+
+  return `~/${relativeToHome.split(path.sep).join('/')}`;
 }
 
 export const encodeSecretPath = encodeExtraPath;
@@ -320,8 +356,11 @@ function buildExtraPathPlan(
   );
 
   const entries = allowlist.map((sourcePath) => ({
-    sourcePath,
-    repoPath: path.join(repoExtraDir, encodeExtraPath(sourcePath)),
+    sourcePath: toPortableSourcePath(sourcePath, locations.xdg.homeDir, platform),
+    repoPath: path.join(
+      repoExtraDir,
+      encodeExtraPath(toPortableSourcePath(sourcePath, locations.xdg.homeDir, platform))
+    ),
   }));
 
   return {

--- a/src/sync/paths.ts
+++ b/src/sync/paths.ts
@@ -355,13 +355,13 @@ function buildExtraPathPlan(
     normalizePath(entry, locations.xdg.homeDir, platform)
   );
 
-  const entries = allowlist.map((sourcePath) => ({
-    sourcePath: toPortableSourcePath(sourcePath, locations.xdg.homeDir, platform),
-    repoPath: path.join(
-      repoExtraDir,
-      encodeExtraPath(toPortableSourcePath(sourcePath, locations.xdg.homeDir, platform))
-    ),
-  }));
+  const entries = allowlist.map((sourcePath) => {
+    const portableSourcePath = toPortableSourcePath(sourcePath, locations.xdg.homeDir, platform);
+    return {
+      sourcePath: portableSourcePath,
+      repoPath: path.join(repoExtraDir, encodeExtraPath(portableSourcePath)),
+    };
+  });
 
   return {
     allowlist,


### PR DESCRIPTION
## Summary
- include modern OpenCode directories by default (agents, instructions, plugins, skills, superpowers) while retaining legacy directory support
- store extraConfigPaths/extraSecretPaths source paths in home-relative form (~/...) to avoid Linux/macOS/WSL path churn
- expand home-relative paths when applying extra manifests so pull/apply stays cross-platform

## Validation
- npm run check
- npm test
