### PR TITLE
fix: strip overrides removes keys missing from local config

### DIFF
--- a/src/sync/config.test.ts
+++ b/src/sync/config.test.ts
@@ -55,6 +55,48 @@ describe('stripOverrides', () => {
 
     expect(stripped).toEqual({ theme: 'opencode', other: true });
   });
+
+  it('strips override object keys missing from local config even when present in base', () => {
+    const base = {
+      mcp: { context7: { url: 'https://example.com' } },
+      server: { port: 8080, hostname: '0.0.0.0' },
+    };
+    const overrides = {
+      mcp: { context7: { headers: { apiKey: 'local-key' } } },
+      server: { port: 8080, hostname: '0.0.0.0' },
+    };
+    const local = {
+      mcp: { context7: { url: 'https://example.com', headers: { apiKey: 'local-key' } } },
+    };
+
+    const stripped = stripOverrides(local, overrides, base);
+
+    expect(stripped).not.toHaveProperty('server');
+    expect(stripped).toEqual({
+      mcp: { context7: { url: 'https://example.com' } },
+    });
+  });
+
+  it('strips override scalar keys missing from local config even when present in base', () => {
+    const base = { theme: 'dark', port: 3000 };
+    const overrides = { theme: 'light', port: 8080 };
+    const local = { theme: 'light' };
+
+    const stripped = stripOverrides(local, overrides, base);
+
+    expect(stripped).not.toHaveProperty('port');
+    expect(stripped).toEqual({ theme: 'dark' });
+  });
+
+  it('strips override keys from local when present in local and base', () => {
+    const base = { theme: 'dark', editor: 'vim' };
+    const overrides = { theme: 'light', editor: 'code' };
+    const local = { theme: 'light', editor: 'code', extra: true };
+
+    const stripped = stripOverrides(local, overrides, base);
+
+    expect(stripped).toEqual({ theme: 'dark', editor: 'vim', extra: true });
+  });
 });
 
 describe('normalizeSyncConfig', () => {

--- a/src/sync/config.ts
+++ b/src/sync/config.ts
@@ -236,7 +236,7 @@ export function stripOverrides(
       continue;
     }
 
-    if (baseValue === undefined) {
+    if (currentValue === undefined || baseValue === undefined) {
       delete result[key];
     } else {
       result[key] = baseValue;


### PR DESCRIPTION
## Summary
- Fixes `stripOverrides()` restoring base values when an override key (object or scalar) is missing from the local config but exists in the base (repo) config
- Adds `currentValue === undefined` check to ensure override-declared keys are always stripped, regardless of base config presence
- Adds 3 new test cases covering object overrides, scalar overrides, and existing-key scenarios

## Problem
When a user adds a config section to `opencode-synced.overrides.jsonc` (e.g., `server`) that exists in the repo's base config but not in the local config, `push` reports "No local changes to push" because `stripOverrides` restores the base value instead of removing it.

Closes #49

## Test plan
- [x] 3 new tests for `stripOverrides` covering the bug scenarios
- [x] All 40 existing tests continue to pass
- [x] Biome lint passes on changed files