### PR TITLE
fix: sync plural OpenCode config directories

### DIFF
--- a/src/sync/apply.test.ts
+++ b/src/sync/apply.test.ts
@@ -3,7 +3,9 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { syncLocalToRepo, syncRepoToLocal } from './apply.js';
+import { normalizeSyncConfig } from './config.js';
 import type { ExtraPathPlan, SyncItem, SyncPlan } from './paths.js';
+import { buildSyncPlan, resolveSyncLocations } from './paths.js';
 
 const EMPTY_EXTRA_PLAN: ExtraPathPlan = {
   allowlist: [],
@@ -273,6 +275,48 @@ describe('syncRepoToLocal for session database', () => {
       await expect(fs.readFile(localDbPath, 'utf8')).resolves.toBe('repo-db-content');
       await expect(fs.stat(`${localDbPath}-wal`)).rejects.toMatchObject({ code: 'ENOENT' });
       await expect(fs.stat(`${localDbPath}-shm`)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+  });
+});
+
+describe('syncing plural OpenCode config directories', () => {
+  it('copies canonical plural directories between isolated homes', async () => {
+    await withTempDir(async (root) => {
+      const machineAHome = path.join(root, 'machine-a');
+      const machineBHome = path.join(root, 'machine-b');
+      const repoRoot = path.join(root, 'repo');
+      const machineALocations = resolveSyncLocations({ HOME: machineAHome }, 'linux');
+      const machineBLocations = resolveSyncLocations({ HOME: machineBHome }, 'linux');
+      const config = normalizeSyncConfig({
+        repo: { owner: 'acme', name: 'config' },
+        includeSecrets: false,
+        includeOpencodeSkills: false,
+        includeAgentsDir: false,
+        includeModelFavorites: false,
+      });
+      const sentinels: Record<string, string> = {
+        'agents/reviewer.md': 'plural-agent',
+        'commands/release.md': 'plural-command',
+        'modes/focus.md': 'plural-mode',
+        'plugins/local.ts': 'plural-plugin',
+        'tools/lint.ts': 'plural-tool',
+      };
+
+      for (const [relativePath, content] of Object.entries(sentinels)) {
+        const sourcePath = path.join(machineALocations.configRoot, relativePath);
+        await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+        await fs.writeFile(sourcePath, content, 'utf8');
+      }
+
+      const machineAPlan = buildSyncPlan(config, machineALocations, repoRoot, 'linux');
+      const machineBPlan = buildSyncPlan(config, machineBLocations, repoRoot, 'linux');
+      await syncLocalToRepo(machineAPlan, null);
+      await syncRepoToLocal(machineBPlan, null);
+
+      for (const [relativePath, content] of Object.entries(sentinels)) {
+        const destinationPath = path.join(machineBLocations.configRoot, relativePath);
+        await expect(fs.readFile(destinationPath, 'utf8')).resolves.toBe(content);
+      }
     });
   });
 });

--- a/src/sync/paths.test.ts
+++ b/src/sync/paths.test.ts
@@ -96,6 +96,11 @@ describe('buildSyncPlan', () => {
       includeSecrets: false,
       extraConfigPaths: [
         `${locations.configRoot}/agent`,
+        `${locations.configRoot}/agents`,
+        `${locations.configRoot}/commands`,
+        `${locations.configRoot}/modes`,
+        `${locations.configRoot}/tools`,
+        `${locations.configRoot}/plugins`,
         `${locations.configRoot}/opencode.json`,
         customConfigPath,
       ],
@@ -104,6 +109,57 @@ describe('buildSyncPlan', () => {
     const plan = buildSyncPlan(normalizeSyncConfig(config), locations, '/repo', 'linux');
 
     expect(plan.extraConfigs.allowlist).toEqual([customConfigPath]);
+  });
+
+  it('includes canonical plural and legacy singular config directories exactly once', () => {
+    const env = { HOME: '/home/test' } as NodeJS.ProcessEnv;
+    const locations = resolveSyncLocations(env, 'linux');
+    const config: SyncConfig = {
+      repo: { owner: 'acme', name: 'config' },
+      includeSecrets: false,
+      includeOpencodeSkills: false,
+      includeAgentsDir: false,
+    };
+
+    const plan = buildSyncPlan(normalizeSyncConfig(config), locations, '/repo', 'linux');
+    const directoryNames = plan.items
+      .filter((item) => item.type === 'dir' && item.localPath.startsWith(locations.configRoot))
+      .map((item) => item.localPath.slice(locations.configRoot.length + 1));
+
+    expect(directoryNames).toEqual([
+      'agent',
+      'agents',
+      'command',
+      'commands',
+      'mode',
+      'modes',
+      'tool',
+      'tools',
+      'themes',
+      'plugin',
+      'plugins',
+    ]);
+    expect(new Set(plan.items.map((item) => item.localPath)).size).toBe(plan.items.length);
+    expect(new Set(plan.items.map((item) => item.repoPath)).size).toBe(plan.items.length);
+  });
+
+  it('filters plural defaults from extra config paths case-insensitively on Windows', () => {
+    const env = {
+      USERPROFILE: 'C:\\Users\\Test',
+      APPDATA: 'C:\\Users\\Test\\AppData\\Roaming',
+      LOCALAPPDATA: 'C:\\Users\\Test\\AppData\\Local',
+    } as NodeJS.ProcessEnv;
+    const locations = resolveSyncLocations(env, 'win32');
+    const pluralAgentsPath = `${locations.configRoot}/agents`;
+    const config: SyncConfig = {
+      repo: { owner: 'acme', name: 'config' },
+      includeSecrets: false,
+      extraConfigPaths: [pluralAgentsPath.toUpperCase()],
+    };
+
+    const plan = buildSyncPlan(normalizeSyncConfig(config), locations, 'C:\\repo', 'win32');
+
+    expect(plan.extraConfigs.allowlist).toEqual([]);
   });
 
   it('includes skills directory in default sync items', () => {

--- a/src/sync/paths.ts
+++ b/src/sync/paths.ts
@@ -52,7 +52,19 @@ const DEFAULT_SYNC_CONFIG_NAME = 'opencode-synced.jsonc';
 const DEFAULT_OVERRIDES_NAME = 'opencode-synced.overrides.jsonc';
 const DEFAULT_STATE_NAME = 'sync-state.json';
 
-const CONFIG_DIRS = ['agent', 'command', 'mode', 'tool', 'themes', 'plugin'];
+const CONFIG_DIRS = [
+  'agent',
+  'agents',
+  'command',
+  'commands',
+  'mode',
+  'modes',
+  'tool',
+  'tools',
+  'themes',
+  'plugin',
+  'plugins',
+];
 const SESSION_DIRS = ['storage/session', 'storage/message', 'storage/part', 'storage/session_diff'];
 const SESSION_DB_FILE = 'opencode.db';
 const PROMPT_STASH_FILES = ['prompt-stash.jsonl', 'prompt-history.jsonl'];


### PR DESCRIPTION
## Summary

- sync OpenCode's canonical plural `agents/`, `commands/`, `modes/`, `plugins/`, and `tools/` config directories by default
- retain every legacy singular directory so existing repositories remain compatible
- keep `skills/` under its existing setting and filter default-directory overlaps from `extraConfigPaths` so each local and repository path is planned once

## Verification

- `bun run check`
- `bun test` — 88 tests passed
- `bun run build`
- feature-focused two-home regression: plural agent, command, mode, plugin, and tool sentinels copied from machine A through the sync repository to machine B
- full isolated GitHub E2E passed: machine A init/push, machine B link, a second machine A push, and machine B pull/replication; the active source tree stayed unchanged and the ephemeral repository was deleted

The E2E harness emitted its known local-materialization warning: machine B's live `AGENTS.md` did not refresh after the final pull, while its isolated sync clone did contain the second sentinel, confirming repository replication. Loopback servers also emitted the expected unsecured-server warning in the isolated sandbox.

Closes #67
