### PR TITLE
feat: support explicit non-GitHub Git remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # opencode-synced
 
-Sync global opencode configuration across machines via a GitHub repo, with optional secrets support for private repos.
+Sync global opencode configuration across machines through Git, with automatic GitHub setup and
+an explicit-URL path for pre-created remotes.
 
 ## Features
 
@@ -14,8 +15,9 @@ Sync global opencode configuration across machines via a GitHub repo, with optio
 
 ## Requirements
 
-- GitHub CLI (`gh`) installed and authenticated (`gh auth login`)
 - Git installed and available on PATH
+- GitHub CLI (`gh`) installed and authenticated (`gh auth login`) when using automatic GitHub
+  creation, discovery, or privacy verification
 
 ## Setup
 
@@ -52,6 +54,32 @@ If auto-detection fails, specify the repo name: `/sync-link my-opencode-config`
 
 After linking, restart opencode to apply the synced settings.
 
+### Pre-created non-GitHub remote
+
+Automatic creation and discovery remain GitHub-only. For GitLab, a self-hosted forge, or another
+Git server, create the remote first and pass its URL explicitly:
+
+```text
+/sync-init ssh://git@git.example.com/team/opencode-config.git
+/sync-link ssh://git@git.example.com/team/opencode-config.git
+```
+
+HTTPS, `ssh://`, SCP-style SSH (`git@host:team/repo.git`), `file://`, and absolute local bare
+repository paths are accepted. `/sync-init <url>` seeds a pre-created empty remote; use
+`/sync-link <url>` for a remote that already contains synced config. Set `repo.branch` explicitly
+when the remote's default branch cannot be detected.
+
+Authentication is delegated to Git. Configure a credential helper or SSH agent; embedded URL
+credentials, query parameters, and fragments are rejected so tokens cannot enter status output,
+logs, Git config, or the synced configuration file. Absolute local remotes are useful for testing
+or same-machine workflows but are not portable across computers.
+
+GitHub repository visibility is verified through `gh`. Other providers do not expose a common
+privacy check, so secrets, prompt history, and sessions fail closed by default. After independently
+confirming the exact remote is private, explicitly acknowledge it when enabling secrets. The
+acknowledgement is fingerprinted in local `sync-state.json`; it is not synced and is invalidated if
+the remote URL changes.
+
 ### Custom repo name or org
 
 You can specify a custom repo name or use an organization:
@@ -68,8 +96,8 @@ Create `~/.config/opencode/opencode-synced.jsonc`:
 ```jsonc
 {
   "repo": {
-    "owner": "your-org",
-    "name": "opencode-config",
+    // Use owner/name for GitHub automation, or url for a pre-created remote.
+    "url": "ssh://git@git.example.com/your-org/opencode-config.git",
     "branch": "main",
   },
   "includeSecrets": false,

--- a/src/command/sync-enable-secrets.md
+++ b/src/command/sync-enable-secrets.md
@@ -5,3 +5,8 @@ description: Enable secrets sync (private repo required)
 Use the opencode_sync tool with command "enable-secrets".
 If the user supplies extra secret paths, pass them via extraSecretPaths.
 If they want MCP secrets committed in a private repo, pass includeMcpSecrets: true.
+
+For a non-GitHub remote, privacy cannot be verified automatically. Pass
+`acknowledgePrivateRemote=true` only if the user explicitly confirms that the exact remote is
+private and may receive secrets or session data. Never infer this acknowledgement. It is stored
+locally for that remote and is not synced.

--- a/src/command/sync-init.md
+++ b/src/command/sync-init.md
@@ -11,6 +11,9 @@ Argument handling:
 
 Rules:
 - Keep repo private unless the user explicitly asked for public.
+- A URL or absolute local path refers to a pre-created Git remote; do not claim it can be created or discovered automatically.
+- Never put credentials in a repo URL. Authentication must be configured through Git credential helpers or SSH.
+- Pass `acknowledgePrivateRemote=true` only when the user explicitly confirms that a non-GitHub remote is private and may receive sensitive sync data.
 - Include `includeSecrets` only if explicitly requested.
 - Include `includeMcpSecrets` only if explicitly requested and secrets are enabled.
 - Include `includeOpencodeSkills` only if explicitly requested.

--- a/src/command/sync-link.md
+++ b/src/command/sync-link.md
@@ -9,6 +9,11 @@ Argument handling:
 - If `$ARGUMENTS` is non-empty, pass `repo="$ARGUMENTS"` exactly as provided. Do not rewrite or shorten it.
 - If `$ARGUMENTS` is empty, let the tool auto-discover.
 
+Rules:
+- Explicit HTTPS, SSH, SCP-style SSH, file, and absolute local remotes are supported.
+- Never put credentials in a repo URL. Authentication must be configured through Git credential helpers or SSH.
+- Do not pass `acknowledgePrivateRemote=true` unless the user explicitly confirms the non-GitHub remote is private and may receive sensitive sync data.
+
 Reminder:
 - Linking overwrites local config except local overrides.
 - After linking, remind to restart opencode.

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,6 +170,12 @@ export const opencodeConfigSync: Plugin = async (ctx) => {
       extraSecretPaths: tool.schema.array(tool.schema.string()).optional(),
       extraConfigPaths: tool.schema.array(tool.schema.string()).optional(),
       localRepoPath: tool.schema.string().optional().describe('Override local repo path'),
+      acknowledgePrivateRemote: tool.schema
+        .boolean()
+        .optional()
+        .describe(
+          'Acknowledge that an explicit non-GitHub remote is private (only after user confirmation)'
+        ),
       setupTurso: tool.schema
         .boolean()
         .optional()
@@ -206,11 +212,14 @@ export const opencodeConfigSync: Plugin = async (ctx) => {
             extraSecretPaths: args.extraSecretPaths,
             extraConfigPaths: args.extraConfigPaths,
             localRepoPath: args.localRepoPath,
+            acknowledgePrivateRemote: args.acknowledgePrivateRemote,
           });
         }
         if (args.command === 'link') {
           return await service.link({
             repo: args.repo ?? args.name,
+            branch: args.branch,
+            acknowledgePrivateRemote: args.acknowledgePrivateRemote,
           });
         }
         if (args.command === 'pull') {
@@ -232,6 +241,7 @@ export const opencodeConfigSync: Plugin = async (ctx) => {
           return await service.enableSecrets({
             extraSecretPaths: args.extraSecretPaths,
             includeMcpSecrets: args.includeMcpSecrets,
+            acknowledgePrivateRemote: args.acknowledgePrivateRemote,
           });
         }
         if (args.command === 'sessions-backend') {

--- a/src/sync/config.test.ts
+++ b/src/sync/config.test.ts
@@ -13,6 +13,7 @@ import {
   normalizeSessionBackend,
   normalizeSyncConfig,
   parseJsonc,
+  sanitizeRepoUrl,
   stripOverrides,
 } from './config.js';
 
@@ -109,6 +110,35 @@ describe('normalizeSyncConfig', () => {
     expect(normalized.sessionBackend.turso.autoSetup).toBe(true);
   });
 
+  it('does not accept a synced privacy acknowledgement', () => {
+    const normalized = normalizeSyncConfig({
+      repo: {
+        url: 'ssh://git@git.example.com/team/config.git',
+        privateRemoteAcknowledged: true,
+      },
+    } as unknown as SyncConfig);
+
+    expect(normalized.repo).toEqual({
+      url: 'ssh://git@git.example.com/team/config.git',
+      branch: undefined,
+    });
+  });
+
+  it('treats an explicit URL as authoritative over owner/name metadata', () => {
+    const normalized = normalizeSyncConfig({
+      repo: {
+        url: 'ssh://git@gitlab.example/team/config.git',
+        owner: 'trusted-github-owner',
+        name: 'trusted-private-repo',
+      },
+    });
+
+    expect(normalized.repo).toEqual({
+      url: 'ssh://git@gitlab.example/team/config.git',
+      branch: undefined,
+    });
+  });
+
   it('normalizes turso backend settings', () => {
     const normalized = normalizeSyncConfig({
       includeSessions: true,
@@ -132,6 +162,37 @@ describe('normalizeSyncConfig', () => {
         autoSetup: false,
       },
     });
+  });
+});
+
+describe('sanitizeRepoUrl', () => {
+  it('accepts credential-free HTTPS, SSH, SCP, file, and absolute remotes', () => {
+    expect(sanitizeRepoUrl('https://gitlab.com/team/config.git')).toBe(
+      'https://gitlab.com/team/config.git'
+    );
+    expect(sanitizeRepoUrl('ssh://git@gitlab.com/team/config.git')).toBe(
+      'ssh://git@gitlab.com/team/config.git'
+    );
+    expect(sanitizeRepoUrl('git@gitlab.com:team/config.git')).toBe(
+      'git@gitlab.com:team/config.git'
+    );
+    expect(sanitizeRepoUrl('file:///tmp/config.git')).toBe('file:///tmp/config.git');
+    expect(sanitizeRepoUrl('/tmp/config.git')).toBe('/tmp/config.git');
+  });
+
+  it('rejects embedded credentials and URL parameters', () => {
+    expect(() => sanitizeRepoUrl('https://user:secret@gitlab.com/team/config.git')).toThrow(
+      'must not contain embedded credentials'
+    );
+    expect(() => sanitizeRepoUrl('https://gitlab.com/team/config.git?token=secret')).toThrow(
+      'must not contain embedded credentials'
+    );
+    expect(() => sanitizeRepoUrl('ssh://git:secret@gitlab.com/team/config.git')).toThrow(
+      'must not contain embedded passwords'
+    );
+    expect(() => sanitizeRepoUrl('https://gitlab.com/team/config.git\nsecret')).toThrow(
+      'control characters'
+    );
   });
 });
 

--- a/src/sync/config.ts
+++ b/src/sync/config.ts
@@ -87,6 +87,10 @@ export interface SyncState {
   lastSecretsHash?: string;
   lastSessionPull?: string;
   lastSessionPush?: string;
+  privateRemoteAcknowledgement?: {
+    remoteFingerprint: string;
+    acknowledgedAt: string;
+  };
 }
 
 export async function pathExists(filePath: string): Promise<boolean> {
@@ -188,7 +192,74 @@ export function normalizeSyncConfig(config: SyncConfig): NormalizedSyncConfig {
     extraSecretPaths: Array.isArray(config.extraSecretPaths) ? config.extraSecretPaths : [],
     extraConfigPaths: Array.isArray(config.extraConfigPaths) ? config.extraConfigPaths : [],
     localRepoPath: config.localRepoPath,
-    repo: config.repo,
+    repo: normalizeRepoConfig(config.repo),
+  };
+}
+
+export function sanitizeRepoUrl(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) return trimmed;
+  if (
+    [...trimmed].some((character) => {
+      const code = character.charCodeAt(0);
+      return code < 32 || code === 127;
+    })
+  ) {
+    throw new Error('Repo URL must not contain control characters.');
+  }
+  if (path.isAbsolute(trimmed) || path.win32.isAbsolute(trimmed)) {
+    return trimmed;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    if (/^[^@\s]+@[^:\s]+:.+$/u.test(trimmed)) {
+      return trimmed;
+    }
+    throw new Error(
+      'Repo URL must be an HTTPS, SSH, Git, file URL, SCP-style SSH remote, or absolute path.'
+    );
+  }
+
+  if (!['http:', 'https:', 'ssh:', 'git:', 'file:'].includes(parsed.protocol)) {
+    throw new Error('Repo URL uses an unsupported protocol.');
+  }
+
+  if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+    if (parsed.username || parsed.password || parsed.search || parsed.hash) {
+      throw new Error(
+        'Repo URL must not contain embedded credentials, query parameters, or fragments. ' +
+          'Configure authentication through Git instead.'
+      );
+    }
+    return parsed.toString();
+  }
+
+  if (parsed.password || parsed.search || parsed.hash) {
+    throw new Error(
+      'Repo URL must not contain embedded passwords, query parameters, or fragments. ' +
+        'Configure authentication through Git instead.'
+    );
+  }
+  return parsed.toString();
+}
+
+function normalizeRepoConfig(input: SyncConfig['repo']): SyncRepoConfig | undefined {
+  if (!input) return undefined;
+
+  if (typeof input.url === 'string') {
+    return {
+      url: sanitizeRepoUrl(input.url),
+      branch: typeof input.branch === 'string' ? input.branch : undefined,
+    };
+  }
+
+  return {
+    owner: typeof input.owner === 'string' ? input.owner : undefined,
+    name: typeof input.name === 'string' ? input.name : undefined,
+    branch: typeof input.branch === 'string' ? input.branch : undefined,
   };
 }
 

--- a/src/sync/repo.test.ts
+++ b/src/sync/repo.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseRepoReference, parseRepoVisibility } from './repo.js';
+import {
+  assertValidRepoBranch,
+  isExplicitGitRemote,
+  parseRepoReference,
+  parseRepoVisibility,
+  redactRemoteCredentials,
+  resolveGitHubRepoIdentifier,
+  resolveRepoBranch,
+} from './repo.js';
 
 describe('parseRepoVisibility', () => {
   it('parses private status', () => {
@@ -64,5 +72,69 @@ describe('parseRepoReference', () => {
     expect(parseRepoReference('acme/opencode/sync', 'ignored')).toBeNull();
     expect(parseRepoReference('git@notgithub:acme/opencode-sync', 'ignored')).toBeNull();
     expect(parseRepoReference('   ', 'ihildy')).toBeNull();
+  });
+});
+
+describe('explicit Git remotes', () => {
+  it('recognizes supported URLs, SCP remotes, and absolute local paths', () => {
+    expect(isExplicitGitRemote('https://gitlab.com/acme/config.git')).toBe(true);
+    expect(isExplicitGitRemote('ssh://git@gitlab.com/acme/config.git')).toBe(true);
+    expect(isExplicitGitRemote('git@gitlab.com:acme/config.git')).toBe(true);
+    expect(isExplicitGitRemote('file:///tmp/config.git')).toBe(true);
+    expect(isExplicitGitRemote('/tmp/config.git')).toBe(true);
+    expect(isExplicitGitRemote('C:\\repos\\config.git')).toBe(true);
+  });
+
+  it('does not treat GitHub shorthand or relative paths as explicit remotes', () => {
+    expect(isExplicitGitRemote('acme/config')).toBe(false);
+    expect(isExplicitGitRemote('config')).toBe(false);
+    expect(isExplicitGitRemote('./config.git')).toBe(false);
+  });
+
+  it('redacts embedded URL userinfo from errors and output', () => {
+    const redacted = redactRemoteCredentials(
+      'fatal: clone https://ian:super-secret@git.example.com/team/config.git failed'
+    );
+
+    expect(redacted).not.toContain('ian');
+    expect(redacted).not.toContain('super-secret');
+    expect(redacted).toContain('https://[REDACTED]@git.example.com/team/config.git');
+  });
+});
+
+describe('Git branch validation', () => {
+  it('accepts normal branch names including slashes', () => {
+    expect(assertValidRepoBranch('main')).toBe('main');
+    expect(assertValidRepoBranch('sync/config')).toBe('sync/config');
+    expect(resolveRepoBranch({ repo: { branch: 'release/v1' } })).toBe('release/v1');
+  });
+
+  it('rejects option-like and invalid ref names', () => {
+    for (const branch of ['--upload-pack=evil', 'bad branch', 'feature..test', 'a@{b', '.hidden']) {
+      expect(() => assertValidRepoBranch(branch)).toThrow('Invalid Git branch name');
+    }
+  });
+});
+
+describe('resolveGitHubRepoIdentifier', () => {
+  it('resolves GitHub owner/name and explicit URLs only', () => {
+    expect(resolveGitHubRepoIdentifier({ repo: { owner: 'acme', name: 'config' } })).toBe(
+      'acme/config'
+    );
+    expect(
+      resolveGitHubRepoIdentifier({ repo: { url: 'ssh://git@github.com/acme/config.git' } })
+    ).toBe('acme/config');
+    expect(
+      resolveGitHubRepoIdentifier({ repo: { url: 'https://gitlab.com/acme/config.git' } })
+    ).toBeNull();
+    expect(
+      resolveGitHubRepoIdentifier({
+        repo: {
+          url: 'https://gitlab.com/acme/config.git',
+          owner: 'trusted-github-owner',
+          name: 'trusted-private-repo',
+        },
+      })
+    ).toBeNull();
   });
 });

--- a/src/sync/repo.ts
+++ b/src/sync/repo.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import type { PluginInput } from '@opencode-ai/plugin';
 
 import type { SyncConfig } from './config.js';
-import { pathExists } from './config.js';
+import { pathExists, sanitizeRepoUrl } from './config.js';
 import {
   RepoDivergedError,
   RepoPrivateRequiredError,
@@ -34,7 +34,7 @@ export function resolveRepoIdentifier(config: SyncConfig): string {
     throw new SyncCommandError('Missing repo configuration.');
   }
 
-  if (repo.url) return repo.url;
+  if (repo.url) return redactRepoUrl(repo.url);
   if (repo.owner && repo.name) return `${repo.owner}/${repo.name}`;
 
   throw new SyncCommandError('Repo configuration must include url or owner/name.');
@@ -42,8 +42,51 @@ export function resolveRepoIdentifier(config: SyncConfig): string {
 
 export function resolveRepoBranch(config: SyncConfig, fallback = 'main'): string {
   const branch = config.repo?.branch;
-  if (branch) return branch;
-  return fallback;
+  return assertValidRepoBranch(branch || fallback);
+}
+
+export function assertValidRepoBranch(branch: string): string {
+  const invalid =
+    !branch ||
+    branch !== branch.trim() ||
+    branch === '@' ||
+    branch.startsWith('-') ||
+    branch.startsWith('.') ||
+    branch.endsWith('.') ||
+    branch.endsWith('/') ||
+    branch.includes('..') ||
+    branch.includes('//') ||
+    branch.includes('@{') ||
+    [...branch].some((character) => character.charCodeAt(0) <= 32) ||
+    /[~^:?*[\\]/.test(branch) ||
+    branch.split('/').some((part) => !part || part.startsWith('.') || part.endsWith('.lock'));
+
+  if (invalid) {
+    throw new SyncCommandError(`Invalid Git branch name: ${redactRemoteCredentials(branch)}`);
+  }
+  return branch;
+}
+
+export function isExplicitGitRemote(input: string): boolean {
+  const value = input.trim();
+  if (!value) return false;
+  if (path.isAbsolute(value) || path.win32.isAbsolute(value)) return true;
+  if (/^[^@\s]+@[^:\s]+:.+$/u.test(value)) return true;
+
+  try {
+    const parsed = new URL(value);
+    return ['http:', 'https:', 'ssh:', 'git:', 'file:'].includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+}
+
+export function redactRepoUrl(input: string): string {
+  return redactRemoteCredentials(sanitizeRepoUrl(input));
+}
+
+export function redactRemoteCredentials(input: string): string {
+  return input.replace(/([a-z][a-z0-9+.-]*:\/\/)([^/@\s]+)@/giu, '$1[REDACTED]@');
 }
 
 export async function ensureRepoCloned(
@@ -52,13 +95,21 @@ export async function ensureRepoCloned(
   repoDir: string
 ): Promise<void> {
   if (await isRepoCloned(repoDir)) {
+    if (config.repo?.url) {
+      await ensureOriginMatches($, repoDir, config.repo.url);
+    }
     return;
   }
 
   await fs.mkdir(path.dirname(repoDir), { recursive: true });
-  const repoIdentifier = resolveRepoIdentifier(config);
+  const repoUrl = config.repo?.url;
 
   try {
+    if (repoUrl) {
+      await $`git clone ${sanitizeRepoUrl(repoUrl)} ${repoDir}`.quiet();
+      return;
+    }
+    const repoIdentifier = resolveRepoIdentifier(config);
     await $`gh repo clone ${repoIdentifier} ${repoDir}`.quiet();
   } catch (error) {
     throw new SyncCommandError(`Failed to clone repo: ${formatError(error)}`);
@@ -66,7 +117,10 @@ export async function ensureRepoCloned(
 }
 
 export async function ensureRepoPrivate($: Shell, config: SyncConfig): Promise<void> {
-  const repoIdentifier = resolveRepoIdentifier(config);
+  const repoIdentifier = resolveGitHubRepoIdentifier(config);
+  if (!repoIdentifier) {
+    throw new RepoVisibilityError('Unable to verify privacy for this non-GitHub remote.');
+  }
   let output: string;
 
   try {
@@ -85,6 +139,49 @@ export async function ensureRepoPrivate($: Shell, config: SyncConfig): Promise<v
   if (!isPrivate) {
     throw new RepoPrivateRequiredError('Secrets sync requires a private GitHub repo.');
   }
+}
+
+export function resolveGitHubRepoIdentifier(config: SyncConfig): string | null {
+  const repo = config.repo;
+  if (!repo) return null;
+  if (repo.url) {
+    const parsed = parseRepoReference(repo.url, '');
+    if (!parsed) return null;
+    return `${parsed.owner}/${parsed.name}`;
+  }
+  if (repo.owner && repo.name) return `${repo.owner}/${repo.name}`;
+  return null;
+}
+
+export function isGitHubRepoConfig(config: SyncConfig): boolean {
+  return resolveGitHubRepoIdentifier(config) !== null;
+}
+
+async function ensureOriginMatches(
+  $: Shell,
+  repoDir: string,
+  configuredUrl: string
+): Promise<void> {
+  let originUrl: string;
+  try {
+    originUrl = (await $`git -C ${repoDir} remote get-url origin`.quiet().text()).trim();
+  } catch (error) {
+    throw new SyncCommandError(`Failed to inspect existing repo origin: ${formatError(error)}`);
+  }
+
+  if (normalizeRemoteForComparison(originUrl) === normalizeRemoteForComparison(configuredUrl)) {
+    return;
+  }
+  throw new SyncCommandError(
+    'Existing local sync repo origin does not match the configured explicit remote.'
+  );
+}
+
+function normalizeRemoteForComparison(input: string): string {
+  const sanitized = sanitizeRepoUrl(input);
+  if (path.isAbsolute(sanitized)) return path.resolve(sanitized);
+  if (path.win32.isAbsolute(sanitized)) return path.win32.normalize(sanitized).toLowerCase();
+  return sanitized.replace(/\/$/u, '');
 }
 
 export function parseRepoVisibility(output: string): boolean {
@@ -106,10 +203,9 @@ export async function fetchAndFastForward(
     throw new SyncCommandError(`Failed to fetch repo: ${formatError(error)}`);
   }
 
-  await checkoutBranch($, repoDir, branch);
-
   const remoteRef = `origin/${branch}`;
-  const remoteExists = await hasRemoteRef($, repoDir, branch);
+  const remoteExists = await hasRemoteBranch($, repoDir, branch);
+  await checkoutBranch($, repoDir, branch, remoteExists);
   if (!remoteExists) {
     return { updated: false, branch };
   }
@@ -172,11 +268,20 @@ async function getCurrentBranch($: Shell, repoDir: string): Promise<string> {
   }
 }
 
-async function checkoutBranch($: Shell, repoDir: string, branch: string): Promise<void> {
+async function checkoutBranch(
+  $: Shell,
+  repoDir: string,
+  branch: string,
+  remoteExists: boolean
+): Promise<void> {
   const exists = await hasLocalBranch($, repoDir, branch);
   try {
     if (exists) {
       await $`git -C ${repoDir} checkout ${branch}`.quiet();
+      return;
+    }
+    if (remoteExists) {
+      await $`git -C ${repoDir} checkout -b ${branch} --track origin/${branch}`.quiet();
       return;
     }
     await $`git -C ${repoDir} checkout -b ${branch}`.quiet();
@@ -194,10 +299,22 @@ async function hasLocalBranch($: Shell, repoDir: string, branch: string): Promis
   }
 }
 
-async function hasRemoteRef($: Shell, repoDir: string, branch: string): Promise<boolean> {
+export async function hasRemoteBranch($: Shell, repoDir: string, branch: string): Promise<boolean> {
   try {
     await $`git -C ${repoDir} show-ref --verify refs/remotes/origin/${branch}`.quiet();
     return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function hasAnyRemoteBranches($: Shell, repoDir: string): Promise<boolean> {
+  try {
+    const output = await $`git -C ${repoDir} for-each-ref refs/remotes/origin`.quiet().text();
+    return output
+      .split('\n')
+      .map((line) => line.trim())
+      .some((line) => Boolean(line) && !line.includes('refs/remotes/origin/HEAD'));
   } catch {
     return false;
   }
@@ -234,8 +351,8 @@ async function getStatusLines($: Shell, repoDir: string): Promise<string[]> {
 }
 
 function formatError(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  return String(error);
+  if (error instanceof Error) return redactRemoteCredentials(error.message);
+  return redactRemoteCredentials(String(error));
 }
 
 export async function repoExists($: Shell, repoIdentifier: string): Promise<boolean> {

--- a/src/sync/service.test.ts
+++ b/src/sync/service.test.ts
@@ -1,0 +1,214 @@
+import { exec } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import type { PluginInput } from '@opencode-ai/plugin';
+import { describe, expect, it } from 'vitest';
+import { loadState, loadSyncConfig, writeSyncConfig } from './config.js';
+import { resolveSyncLocations } from './paths.js';
+import { createSyncService } from './service.js';
+
+const GIT_CONTEXT_KEYS = [
+  'GIT_DIR',
+  'GIT_WORK_TREE',
+  'GIT_INDEX_FILE',
+  'GIT_COMMON_DIR',
+  'GIT_OBJECT_DIRECTORY',
+  'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+  'GIT_PREFIX',
+] as const;
+
+const ENV_KEYS = [
+  'HOME',
+  'XDG_CONFIG_HOME',
+  'XDG_DATA_HOME',
+  'XDG_STATE_HOME',
+  'opencode_config_dir',
+  'GIT_AUTHOR_NAME',
+  'GIT_AUTHOR_EMAIL',
+  'GIT_COMMITTER_NAME',
+  'GIT_COMMITTER_EMAIL',
+  ...GIT_CONTEXT_KEYS,
+] as const;
+
+const execAsync = promisify(exec);
+type ExecResult = Awaited<ReturnType<typeof execAsync>>;
+
+interface TestShellCommand extends Promise<ExecResult> {
+  quiet: () => TestShellCommand;
+  text: () => Promise<string>;
+}
+
+function createTestShell(): PluginInput['$'] {
+  const shell = (strings: TemplateStringsArray, ...values: unknown[]): TestShellCommand => {
+    const env = { ...process.env };
+    for (const key of GIT_CONTEXT_KEYS) delete env[key];
+    const command = strings.reduce(
+      (result, segment, index) =>
+        result + segment + (index < values.length ? shellQuote(values[index]) : ''),
+      ''
+    );
+    const execution = execAsync(command, { env }) as TestShellCommand;
+    execution.quiet = () => execution;
+    execution.text = async () => (await execution).stdout;
+    return execution;
+  };
+  return shell as unknown as PluginInput['$'];
+}
+
+function shellQuote(value: unknown): string {
+  return `'${String(value).replaceAll("'", `'\\''`)}'`;
+}
+
+function createClient(): PluginInput['client'] {
+  return {
+    app: { log: async () => ({}) },
+    config: { get: async () => ({ data: {} }) },
+    session: {
+      create: async () => ({ data: null }),
+      delete: async () => ({}),
+      prompt: async () => ({ data: null }),
+      status: async () => ({ data: {} }),
+    },
+    tui: { showToast: async () => ({}) },
+  } as unknown as PluginInput['client'];
+}
+
+function useIsolatedHome(homeDir: string): void {
+  process.env.HOME = homeDir;
+  process.env.XDG_CONFIG_HOME = path.join(homeDir, 'config');
+  process.env.XDG_DATA_HOME = path.join(homeDir, 'data');
+  process.env.XDG_STATE_HOME = path.join(homeDir, 'state');
+  delete process.env.opencode_config_dir;
+}
+
+async function withIsolatedEnvironment(run: (root: string) => Promise<void>): Promise<void> {
+  const original = new Map<string, string | undefined>(
+    ENV_KEYS.map((key) => [key, process.env[key]])
+  );
+  const root = await fs.mkdtemp(path.join(tmpdir(), 'opencode-sync-service-'));
+  process.env.GIT_AUTHOR_NAME = 'opencode-synced test';
+  process.env.GIT_AUTHOR_EMAIL = 'opencode-synced@example.invalid';
+  process.env.GIT_COMMITTER_NAME = 'opencode-synced test';
+  process.env.GIT_COMMITTER_EMAIL = 'opencode-synced@example.invalid';
+  for (const key of GIT_CONTEXT_KEYS) delete process.env[key];
+
+  try {
+    await run(root);
+  } finally {
+    for (const [key, value] of original) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+describe('explicit Git remote service flow', () => {
+  it('initializes, links, pushes, and pulls through a local bare remote', async () => {
+    await withIsolatedEnvironment(async (root) => {
+      const testShell = createTestShell();
+      const remotePath = path.join(root, 'sync-remote.git');
+      const replacementRemotePath = path.join(root, 'replacement-remote.git');
+      await testShell`git init --bare ${remotePath}`.quiet();
+      await testShell`git init --bare ${replacementRemotePath}`.quiet();
+
+      const machineAHome = path.join(root, 'machine-a');
+      useIsolatedHome(machineAHome);
+      const machineALocations = resolveSyncLocations();
+      await fs.mkdir(machineALocations.configRoot, { recursive: true });
+      await fs.writeFile(
+        path.join(machineALocations.configRoot, 'opencode.json'),
+        '{"theme":"machine-a"}\n',
+        'utf8'
+      );
+      const machineAService = createSyncService({ client: createClient(), $: testShell });
+
+      const initResult = await machineAService.init({
+        repo: remotePath,
+        branch: 'sync/config',
+      });
+      expect(initResult).toContain(`Repo: ${remotePath}`);
+      expect(initResult).toContain('Branch: sync/config');
+      await testShell`git --git-dir ${remotePath} show-ref --verify refs/heads/sync/config`.quiet();
+
+      const machineAConfig = await loadSyncConfig(machineALocations);
+      expect(machineAConfig?.repo).toEqual({ url: remotePath, branch: 'sync/config' });
+
+      const machineBHome = path.join(root, 'machine-b');
+      useIsolatedHome(machineBHome);
+      const machineBLocations = resolveSyncLocations();
+      const machineBService = createSyncService({ client: createClient(), $: testShell });
+      const linkResult = await machineBService.link({
+        repo: remotePath,
+        branch: 'sync/config',
+      });
+
+      expect(linkResult).toContain(`Linked to existing sync repo: ${remotePath}`);
+      expect(linkResult).toContain('Remote privacy was not verified');
+      await expect(
+        fs.readFile(path.join(machineBLocations.configRoot, 'opencode.json'), 'utf8')
+      ).resolves.toContain('machine-a');
+
+      await fs.writeFile(
+        path.join(machineBLocations.configRoot, 'opencode.json'),
+        '{"theme":"machine-b"}\n',
+        'utf8'
+      );
+      await machineBService.push();
+
+      useIsolatedHome(machineAHome);
+      await machineAService.pull();
+      await expect(
+        fs.readFile(path.join(machineALocations.configRoot, 'opencode.json'), 'utf8')
+      ).resolves.toContain('machine-b');
+
+      useIsolatedHome(path.join(root, 'machine-c'));
+      const machineCService = createSyncService({ client: createClient(), $: testShell });
+      await expect(
+        machineCService.init({ repo: remotePath, branch: 'sync/config' })
+      ).rejects.toThrow('Use /sync-link <url> instead');
+
+      useIsolatedHome(machineBHome);
+      await expect(machineBService.enableSecrets()).rejects.toThrow('privacy cannot be verified');
+      await expect(machineBService.enableSecrets({ acknowledgePrivateRemote: true })).resolves.toBe(
+        'Secrets sync enabled for this repo.'
+      );
+
+      const state = await loadState(machineBLocations);
+      expect(state.privateRemoteAcknowledgement?.remoteFingerprint).toMatch(/^[a-f0-9]{64}$/u);
+      const acknowledgedConfig = await loadSyncConfig(machineBLocations);
+      expect(acknowledgedConfig?.repo).toEqual({ url: remotePath, branch: 'sync/config' });
+
+      if (!acknowledgedConfig) throw new Error('Expected machine B sync config.');
+      await writeSyncConfig(machineBLocations, {
+        ...acknowledgedConfig,
+        repo: { url: replacementRemotePath, branch: 'sync/config' },
+      });
+      await expect(machineBService.enableSecrets()).rejects.toThrow('privacy cannot be verified');
+
+      useIsolatedHome(path.join(root, 'machine-d'));
+      const machineDService = createSyncService({ client: createClient(), $: testShell });
+      await expect(
+        machineDService.init({
+          repo: replacementRemotePath,
+          branch: 'sync/config',
+          includeSessions: true,
+        })
+      ).rejects.toThrow('privacy cannot be verified');
+      await expect(
+        machineDService.init({
+          repo: replacementRemotePath,
+          branch: 'sync/config',
+          includeSessions: true,
+          acknowledgePrivateRemote: true,
+        })
+      ).resolves.toContain('opencode-synced configured');
+    });
+  }, 30_000);
+});

--- a/src/sync/service.ts
+++ b/src/sync/service.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
@@ -28,10 +29,16 @@ import {
   findSyncRepo,
   getAuthenticatedUser,
   getRepoStatus,
+  hasAnyRemoteBranches,
   hasLocalChanges,
+  hasRemoteBranch,
+  isExplicitGitRemote,
+  isGitHubRepoConfig,
   isRepoCloned,
   parseRepoReference,
   pushBranch,
+  redactRemoteCredentials,
+  redactRepoUrl,
   repoExists,
   resolveRepoBranch,
   resolveRepoIdentifier,
@@ -81,10 +88,13 @@ interface InitOptions {
   extraSecretPaths?: string[];
   extraConfigPaths?: string[];
   localRepoPath?: string;
+  acknowledgePrivateRemote?: boolean;
 }
 
 interface LinkOptions {
   repo?: string;
+  branch?: string;
+  acknowledgePrivateRemote?: boolean;
 }
 
 export interface SyncService {
@@ -101,6 +111,7 @@ export interface SyncService {
   enableSecrets: (_options?: {
     extraSecretPaths?: string[];
     includeMcpSecrets?: boolean;
+    acknowledgePrivateRemote?: boolean;
   }) => Promise<string>;
   sessionsBackend: (_options: {
     backend?: 'git' | 'turso';
@@ -253,6 +264,7 @@ export function createSyncService(ctx: SyncServiceContext): SyncService {
     { backend: SecretsBackend } | { message: string }
   > => {
     const config = await getConfigOrThrow(locations);
+    await ensureSensitiveSyncPolicy(ctx, locations, config);
     const resolution = resolveSecretsBackendConfig(config);
     if (resolution.state === 'none') {
       return {
@@ -618,6 +630,7 @@ export function createSyncService(ctx: SyncServiceContext): SyncService {
         }
         try {
           assertValidSecretsBackend(config);
+          await ensureSensitiveSyncPolicy(ctx, locations, config);
           let tursoWarning: string | null = null;
           if (isTursoSessionBackend(config)) {
             try {
@@ -736,18 +749,34 @@ export function createSyncService(ctx: SyncServiceContext): SyncService {
 
         const repoIdentifier = resolveRepoIdentifier(config);
         const isPrivate = options.private ?? true;
+        const explicitRemote = Boolean(config.repo?.url);
 
-        const exists = await repoExists(ctx.$, repoIdentifier);
         let created = false;
-        if (!exists) {
-          await createRepo(ctx.$, config, isPrivate);
-          created = true;
+        if (!explicitRemote) {
+          const exists = await repoExists(ctx.$, repoIdentifier);
+          if (!exists) {
+            await createRepo(ctx.$, config, isPrivate);
+            created = true;
+          }
         }
 
-        await writeSyncConfig(locations, config);
         const repoRoot = resolveRepoRoot(config, locations);
         await ensureRepoCloned(ctx.$, config, repoRoot);
-        await ensureSecretsPolicy(ctx, config);
+        const branch = await resolveBranch(ctx, config, repoRoot);
+        await fetchAndFastForward(ctx.$, repoRoot, branch);
+        config.repo = { ...config.repo, branch };
+
+        if (explicitRemote && (await hasAnyRemoteBranches(ctx.$, repoRoot))) {
+          throw new SyncCommandError(
+            'The explicit Git remote already contains a branch. Use /sync-link <url> instead.'
+          );
+        }
+        await writeSyncConfig(locations, config);
+
+        if (options.acknowledgePrivateRemote === true) {
+          await acknowledgePrivateRemote(locations, config);
+        }
+        await ensureSensitiveSyncPolicy(ctx, locations, config);
 
         const initNotes: string[] = [];
         if (isTursoSessionBackend(config) && options.setupTurso !== false) {
@@ -768,7 +797,9 @@ export function createSyncService(ctx: SyncServiceContext): SyncService {
           initNotes.push(`Session bootstrap: ${cycle.summary}`);
         }
 
-        if (created) {
+        const shouldBootstrap =
+          created || (explicitRemote && !(await hasRemoteBranch(ctx.$, repoRoot, branch)));
+        if (shouldBootstrap) {
           const overrides = await loadOverrides(locations);
           const plan = buildSyncPlan(config, locations, repoRoot);
           await syncLocalToRepo(plan, overrides, {
@@ -778,7 +809,6 @@ export function createSyncService(ctx: SyncServiceContext): SyncService {
 
           const dirty = await hasLocalChanges(ctx.$, repoRoot);
           if (dirty) {
-            const branch = resolveRepoBranch(config);
             await commitAll(ctx.$, repoRoot, 'Initial sync from opencode-synced');
             await pushBranch(ctx.$, repoRoot, branch);
             await updateState(locations, { lastPush: new Date().toISOString() });
@@ -788,7 +818,7 @@ export function createSyncService(ctx: SyncServiceContext): SyncService {
         const lines = [
           'opencode-synced configured.',
           `Repo: ${repoIdentifier}${created ? ' (created)' : ''}`,
-          `Branch: ${resolveRepoBranch(config)}`,
+          `Branch: ${branch}`,
           `Local repo: ${repoRoot}`,
         ];
         if (initNotes.length > 0) {
@@ -811,57 +841,80 @@ export function createSyncService(ctx: SyncServiceContext): SyncService {
           );
         }
 
-        const found = await findSyncRepo(ctx.$, options.repo, {
-          disableAutoDiscovery: disableAutoRepoDiscovery,
-        });
+        const explicitRemote = options.repo ? isExplicitGitRemote(options.repo) : false;
+        let config: NormalizedSyncConfig;
+        let repoDisplay: string;
+        let remotePrivacy: 'private' | 'public' | 'unverified';
 
-        if (!found) {
-          const searchedFor = options.repo
-            ? `"${options.repo}"`
-            : disableAutoRepoDiscovery
-              ? '(none; auto-discovery disabled)'
-              : 'common sync repo names (my-opencode-config, opencode-config, etc.)';
+        if (explicitRemote && options.repo) {
+          config = normalizeSyncConfig({
+            repo: { url: options.repo, branch: options.branch },
+            includeSecrets: false,
+            includeMcpSecrets: false,
+            includeSessions: false,
+            includePromptStash: false,
+            extraSecretPaths: [],
+            extraConfigPaths: [],
+          });
+          repoDisplay = redactRepoUrl(options.repo);
+          remotePrivacy = 'unverified';
+        } else {
+          const found = await findSyncRepo(ctx.$, options.repo, {
+            disableAutoDiscovery: disableAutoRepoDiscovery,
+          });
 
-          const lines = [
-            `Could not find an existing sync repo. Searched for: ${searchedFor}`,
-            '',
-            'To link to an existing repo, run:',
-            '  /sync-link <owner/repo>',
-            '',
-            'To create a new sync repo, run:',
-            '  /sync-init',
-          ];
-          return lines.join('\n');
-        }
+          if (!found) {
+            const searchedFor = options.repo
+              ? `"${redactRemoteCredentials(options.repo)}"`
+              : disableAutoRepoDiscovery
+                ? '(none; auto-discovery disabled)'
+                : 'common sync repo names (my-opencode-config, opencode-config, etc.)';
 
-        if (strictLinkRepo) {
-          const linkedIdentifier = `${found.owner}/${found.name}`.toLowerCase();
-          const expectedIdentifier = `${strictLinkRepo.owner}/${strictLinkRepo.name}`.toLowerCase();
-          if (linkedIdentifier !== expectedIdentifier) {
-            throw new SyncCommandError(
-              `Strict link mode expected repo ${strictLinkRepo.owner}/${strictLinkRepo.name}, ` +
-                `but resolved ${found.owner}/${found.name}.`
-            );
+            const lines = [
+              `Could not find an existing sync repo. Searched for: ${searchedFor}`,
+              '',
+              'To link to an existing repo, run:',
+              '  /sync-link <owner/repo-or-url>',
+              '',
+              'To create a new GitHub sync repo, run:',
+              '  /sync-init',
+            ];
+            return lines.join('\n');
           }
-        }
 
-        const config = normalizeSyncConfig({
-          repo: { owner: found.owner, name: found.name },
-          includeSecrets: false,
-          includeMcpSecrets: false,
-          includeSessions: false,
-          includePromptStash: false,
-          extraSecretPaths: [],
-          extraConfigPaths: [],
-        });
+          if (strictLinkRepo) {
+            const linkedIdentifier = `${found.owner}/${found.name}`.toLowerCase();
+            const expectedIdentifier =
+              `${strictLinkRepo.owner}/${strictLinkRepo.name}`.toLowerCase();
+            if (linkedIdentifier !== expectedIdentifier) {
+              throw new SyncCommandError(
+                `Strict link mode expected repo ${strictLinkRepo.owner}/${strictLinkRepo.name}, ` +
+                  `but resolved ${found.owner}/${found.name}.`
+              );
+            }
+          }
+
+          config = normalizeSyncConfig({
+            repo: { owner: found.owner, name: found.name, branch: options.branch },
+            includeSecrets: false,
+            includeMcpSecrets: false,
+            includeSessions: false,
+            includePromptStash: false,
+            extraSecretPaths: [],
+            extraConfigPaths: [],
+          });
+          repoDisplay = `${found.owner}/${found.name}`;
+          remotePrivacy = found.isPrivate ? 'private' : 'public';
+        }
 
         await writeSyncConfig(locations, config);
         const repoRoot = resolveRepoRoot(config, locations);
         await ensureRepoCloned(ctx.$, config, repoRoot);
 
         const branch = await resolveBranch(ctx, config, repoRoot);
-
         await fetchAndFastForward(ctx.$, repoRoot, branch);
+        config.repo = { ...config.repo, branch };
+        await writeSyncConfig(locations, config);
 
         const overrides = await loadOverrides(locations);
         const plan = buildSyncPlan(config, locations, repoRoot);
@@ -874,6 +927,14 @@ export function createSyncService(ctx: SyncServiceContext): SyncService {
 
         const linkNotes: string[] = [];
         const syncedConfig = await loadSyncConfig(locations);
+        if (syncedConfig) {
+          syncedConfig.repo = { ...config.repo, branch };
+          await writeSyncConfig(locations, syncedConfig);
+          if (options.acknowledgePrivateRemote === true) {
+            await acknowledgePrivateRemote(locations, syncedConfig);
+          }
+          await ensureSensitiveSyncPolicy(ctx, locations, syncedConfig);
+        }
         if (syncedConfig && isTursoSessionBackend(syncedConfig)) {
           const setup = await runTursoSetup(syncedConfig, { allowLogin: true });
           linkNotes.push(setup.message);
@@ -889,16 +950,18 @@ export function createSyncService(ctx: SyncServiceContext): SyncService {
         }
 
         const lines = [
-          `Linked to existing sync repo: ${found.owner}/${found.name}`,
+          `Linked to existing sync repo: ${repoDisplay}`,
           '',
           'Your local opencode config has been OVERWRITTEN with the synced config.',
           'Your local overrides file was preserved and applied on top.',
           '',
           'Restart opencode to apply the new settings.',
           '',
-          found.isPrivate
+          remotePrivacy === 'private'
             ? 'To enable secrets sync, run: /sync-enable-secrets'
-            : 'Note: Repo is public. Secrets sync is disabled.',
+            : remotePrivacy === 'public'
+              ? 'Note: Repo is public. Secrets sync is disabled.'
+              : 'Remote privacy was not verified. Secrets sync requires an explicit private-remote acknowledgement.',
         ];
         if (linkNotes.length > 0) {
           lines.push('', ...linkNotes);
@@ -912,7 +975,7 @@ export function createSyncService(ctx: SyncServiceContext): SyncService {
         const config = await getConfigOrThrow(locations);
         const repoRoot = resolveRepoRoot(config, locations);
         await ensureRepoCloned(ctx.$, config, repoRoot);
-        await ensureSecretsPolicy(ctx, config);
+        await ensureSensitiveSyncPolicy(ctx, locations, config);
         await ensureAuthFilesNotTracked(repoRoot, config);
 
         const branch = await resolveBranch(ctx, config, repoRoot);
@@ -961,7 +1024,7 @@ export function createSyncService(ctx: SyncServiceContext): SyncService {
         const config = await getConfigOrThrow(locations);
         const repoRoot = resolveRepoRoot(config, locations);
         await ensureRepoCloned(ctx.$, config, repoRoot);
-        await ensureSecretsPolicy(ctx, config);
+        await ensureSensitiveSyncPolicy(ctx, locations, config);
         await ensureAuthFilesNotTracked(repoRoot, config);
         const branch = await resolveBranch(ctx, config, repoRoot);
 
@@ -1062,7 +1125,11 @@ export function createSyncService(ctx: SyncServiceContext): SyncService {
           return await backend.status();
         })
       ),
-    enableSecrets: (options?: { extraSecretPaths?: string[]; includeMcpSecrets?: boolean }) =>
+    enableSecrets: (options?: {
+      extraSecretPaths?: string[];
+      includeMcpSecrets?: boolean;
+      acknowledgePrivateRemote?: boolean;
+    }) =>
       runExclusive(async () => {
         const config = await getConfigOrThrow(locations);
         config.includeSecrets = true;
@@ -1073,7 +1140,10 @@ export function createSyncService(ctx: SyncServiceContext): SyncService {
           config.includeMcpSecrets = options.includeMcpSecrets;
         }
 
-        await ensureRepoPrivate(ctx.$, config);
+        if (options?.acknowledgePrivateRemote === true) {
+          await acknowledgePrivateRemote(locations, config);
+        }
+        await ensureSensitiveSyncPolicy(ctx, locations, config);
         await writeSyncConfig(locations, config);
 
         return 'Secrets sync enabled for this repo.';
@@ -1103,6 +1173,7 @@ export function createSyncService(ctx: SyncServiceContext): SyncService {
             type: backend,
           },
         });
+        await ensureSensitiveSyncPolicy(ctx, locations, nextConfig);
 
         const notes: string[] = [];
         if (backend === 'turso') {
@@ -1144,6 +1215,7 @@ export function createSyncService(ctx: SyncServiceContext): SyncService {
     sessionsSetupTurso: (options?: { forceTokenRefresh?: boolean }) =>
       runExclusive(async () => {
         const config = await getConfigOrThrow(locations);
+        await ensureSensitiveSyncPolicy(ctx, locations, config);
         if (!config.includeSessions) {
           throw new SyncCommandError(
             'Session sync is disabled. Enable includeSessions=true before Turso setup.'
@@ -1182,6 +1254,7 @@ export function createSyncService(ctx: SyncServiceContext): SyncService {
     sessionsMigrateTurso: (options?: { setupTurso?: boolean }) =>
       runExclusive(async () => {
         const config = await getConfigOrThrow(locations);
+        await ensureSensitiveSyncPolicy(ctx, locations, config);
         if (!config.includeSessions) {
           throw new SyncCommandError(
             'Session sync is disabled. Enable includeSessions=true before migration.'
@@ -1231,6 +1304,7 @@ export function createSyncService(ctx: SyncServiceContext): SyncService {
     sessionsCleanupGit: () =>
       runExclusive(async () => {
         const config = await getConfigOrThrow(locations);
+        await ensureSensitiveSyncPolicy(ctx, locations, config);
         if (!isTursoSessionBackend(config)) {
           throw new SyncCommandError(
             'Cleanup is only available when includeSessions=true and sessionBackend=turso.'
@@ -1350,7 +1424,7 @@ async function runStartup(
   log.debug('Starting sync', { repoRoot });
 
   await ensureRepoCloned(ctx.$, config, repoRoot);
-  await ensureSecretsPolicy(ctx, config);
+  await ensureSensitiveSyncPolicy(ctx, locations, config);
   await options.ensureAuthFilesNotTracked(repoRoot, config);
   const branch = await resolveBranch(ctx, config, repoRoot);
   log.debug('Resolved branch', { branch });
@@ -1415,12 +1489,57 @@ async function getConfigOrThrow(
   return config;
 }
 
-async function ensureSecretsPolicy(
+async function ensureSensitiveSyncPolicy(
   ctx: SyncServiceContext,
+  locations: ReturnType<typeof resolveSyncLocations>,
   config: ReturnType<typeof normalizeSyncConfig>
-) {
-  if (!config.includeSecrets) return;
-  await ensureRepoPrivate(ctx.$, config);
+): Promise<void> {
+  if (!hasSensitiveSync(config)) return;
+  if (isGitHubRepoConfig(config)) {
+    await ensureRepoPrivate(ctx.$, config);
+    return;
+  }
+
+  const expectedFingerprint = resolvePrivateRemoteFingerprint(config);
+  const state = await loadState(locations);
+  if (state.privateRemoteAcknowledgement?.remoteFingerprint === expectedFingerprint) {
+    return;
+  }
+  throw new SyncCommandError(
+    'Sensitive sync for this non-GitHub remote is blocked because privacy cannot be verified. ' +
+      'Confirm the remote is private, then explicitly acknowledge it for this machine.'
+  );
+}
+
+function hasSensitiveSync(config: NormalizedSyncConfig): boolean {
+  return Boolean(
+    config.includeSecrets ||
+      config.includeMcpSecrets ||
+      config.includeSessions ||
+      config.includePromptStash
+  );
+}
+
+async function acknowledgePrivateRemote(
+  locations: ReturnType<typeof resolveSyncLocations>,
+  config: NormalizedSyncConfig
+): Promise<void> {
+  if (isGitHubRepoConfig(config)) return;
+  const remoteFingerprint = resolvePrivateRemoteFingerprint(config);
+  await updateState(locations, {
+    privateRemoteAcknowledgement: {
+      remoteFingerprint,
+      acknowledgedAt: new Date().toISOString(),
+    },
+  });
+}
+
+function resolvePrivateRemoteFingerprint(config: NormalizedSyncConfig): string {
+  const remote = config.repo?.url;
+  if (!remote) {
+    throw new SyncCommandError('Private-remote acknowledgement requires an explicit repo URL.');
+  }
+  return crypto.createHash('sha256').update(remote).digest('hex');
 }
 
 async function resolveBranch(
@@ -1468,7 +1587,7 @@ async function resolveRepoFromInit($: Shell, options: InitOptions) {
     return { owner: options.owner, name: options.name, branch: options.branch };
   }
   if (options.repo) {
-    if (options.repo.includes('://') || options.repo.endsWith('.git')) {
+    if (isExplicitGitRemote(options.repo)) {
       return { url: options.repo, branch: options.branch };
     }
     if (options.repo.includes('/')) {
@@ -1508,8 +1627,8 @@ async function createRepo(
 }
 
 function formatError(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  return String(error);
+  if (error instanceof Error) return redactRemoteCredentials(error.message);
+  return redactRemoteCredentials(String(error));
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Summary

- accept pre-created HTTPS, SSH, SCP-style SSH, `file://`, and absolute local Git remotes through `repo.url`, `/sync-init <url>`, and `/sync-link <url>`
- keep automatic repository creation, discovery, and visibility checks GitHub-only
- delegate generic-remote authentication to Git while rejecting embedded URL credentials and redacting remote userinfo in errors/output
- fail closed for secrets, prompt history, and sessions until the user acknowledges the exact private remote on that machine; store only a SHA-256 remote fingerprint in local `sync-state.json`
- validate branch names, persist detected branches, and reject mismatched existing origins

## Verification

- `bun run check`
- `bun test` (96 tests, 210 assertions)
- `bun run build`
- local bare-remote two-home E2E covering init, non-default branch tracking, link, push, pull, privacy refusal/acknowledgement, and acknowledgement invalidation after a URL change
- isolated GitHub two-instance E2E passed; the ephemeral repository was deleted and the active source tree stayed clean

## Scope

Provider-neutral repository creation and discovery are intentionally out of scope. Users must pre-create non-GitHub remotes and configure their Git credential helper or SSH agent.

Closes #61