### PR TITLE
fix: safely sync large session files

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,21 @@ Best-effort session artifact sync via Git paths:
 
 This mode can conflict with concurrent writers.
 
+Large `opencode.db` files and legacy files under `storage/message/` are represented as a small,
+versioned pointer plus 40 MiB parts once they exceed 50 MiB. Parts live in the plugin-owned
+`.opencode-synced/chunks/v1/` namespace. Each pointer records the exact part count, total size,
+file mode, and SHA-256 digest; pulls validate the complete representation before atomically replacing
+the local file or database bundle. Readers continue to accept ordinary unchunked session files.
+
+The format rejects symlinks, unknown/missing parts, invalid metadata, files larger than 4 GiB, and
+representations with more than 128 parts. The chunk namespace has a versioned ownership marker, so
+cleanup refuses to touch a colliding or corrupt directory.
+
+If an earlier failed push already committed a file over GitHub's size limit, that blob remains in
+the unpushed commit ancestry even after the working tree is chunked. `opencode-synced` detects this
+and stops instead of rewriting history automatically. The error includes exact commands that first
+create a backup branch and then rebuild only the unpushed commits from the remote branch.
+
 #### Turso backend (`sessionBackend.type = "turso"`)
 
 Concurrent-safe snapshot backend for sessions:

--- a/src/sync/apply.test.ts
+++ b/src/sync/apply.test.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { syncLocalToRepo, syncRepoToLocal } from './apply.js';
 import { normalizeSyncConfig } from './config.js';
 import type { ExtraPathPlan, SyncItem, SyncPlan } from './paths.js';
@@ -12,6 +12,10 @@ const EMPTY_EXTRA_PLAN: ExtraPathPlan = {
   manifestPath: '',
   entries: [],
 };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function createPlan(repoRoot: string, homeDir: string, items: SyncItem[]): SyncPlan {
   return {
@@ -275,6 +279,227 @@ describe('syncRepoToLocal for session database', () => {
       await expect(fs.readFile(localDbPath, 'utf8')).resolves.toBe('repo-db-content');
       await expect(fs.stat(`${localDbPath}-wal`)).rejects.toMatchObject({ code: 'ENOENT' });
       await expect(fs.stat(`${localDbPath}-shm`)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+  });
+});
+
+describe('chunked Git session items', () => {
+  const chunkOptions = {
+    thresholdBytes: 8,
+    chunkBytes: 5,
+    maxFileBytes: 256,
+    maxChunks: 64,
+    bufferBytes: 3,
+  };
+
+  it('round-trips large legacy messages without colliding with chunk-like filenames', async () => {
+    await withTempDir(async (root) => {
+      const repoRoot = path.join(root, 'repo');
+      const localMessageDir = path.join(root, 'local', 'storage', 'message');
+      const repoMessageDir = path.join(repoRoot, 'data', 'storage', 'message');
+      await fs.mkdir(localMessageDir, { recursive: true });
+      await fs.writeFile(path.join(localMessageDir, 'message-1.json'), '0123456789abcdef');
+      await fs.writeFile(path.join(localMessageDir, 'message-1.json.ocsync-chunk.0'), 'user-data');
+
+      const plan = createPlan(repoRoot, path.join(root, 'local'), [
+        {
+          localPath: localMessageDir,
+          repoPath: repoMessageDir,
+          type: 'dir',
+          isSecret: true,
+          isConfigFile: false,
+          preserveWhenMissing: true,
+          chunkLargeFiles: true,
+        },
+      ]);
+      await syncLocalToRepo(plan, null, { chunkOptions });
+
+      await fs.rm(localMessageDir, { recursive: true });
+      await syncRepoToLocal(plan, null, { chunkOptions });
+      await expect(fs.readFile(path.join(localMessageDir, 'message-1.json'), 'utf8')).resolves.toBe(
+        '0123456789abcdef'
+      );
+      await expect(
+        fs.readFile(path.join(localMessageDir, 'message-1.json.ocsync-chunk.0'), 'utf8')
+      ).resolves.toBe('user-data');
+    });
+  });
+
+  it('does not replace an existing legacy session directory when validation fails', async () => {
+    await withTempDir(async (root) => {
+      const repoRoot = path.join(root, 'repo');
+      const localMessageDir = path.join(root, 'local', 'storage', 'message');
+      const repoMessageDir = path.join(repoRoot, 'data', 'storage', 'message');
+      await fs.mkdir(localMessageDir, { recursive: true });
+      await fs.writeFile(path.join(localMessageDir, 'message-1.json'), '0123456789abcdef');
+      const plan = createPlan(repoRoot, path.join(root, 'local'), [
+        {
+          localPath: localMessageDir,
+          repoPath: repoMessageDir,
+          type: 'dir',
+          isSecret: true,
+          isConfigFile: false,
+          preserveWhenMissing: true,
+          chunkLargeFiles: true,
+        },
+      ]);
+      await syncLocalToRepo(plan, null, { chunkOptions });
+
+      const pointer = JSON.parse(
+        await fs.readFile(path.join(repoMessageDir, 'message-1.json'), 'utf8')
+      ) as { id: string };
+      await fs.rm(
+        path.join(repoRoot, '.opencode-synced', 'chunks', 'v1', pointer.id, '000001.part')
+      );
+      await fs.rm(localMessageDir, { recursive: true });
+      await fs.mkdir(localMessageDir, { recursive: true });
+      await fs.writeFile(path.join(localMessageDir, 'existing.json'), 'keep');
+
+      await expect(syncRepoToLocal(plan, null, { chunkOptions })).rejects.toThrow(/missing/u);
+      await expect(fs.readFile(path.join(localMessageDir, 'existing.json'), 'utf8')).resolves.toBe(
+        'keep'
+      );
+    });
+  });
+
+  it('preserves the entire destination DB bundle when a later sidecar is corrupt', async () => {
+    await withTempDir(async (root) => {
+      const repoRoot = path.join(root, 'repo');
+      const sourceDb = path.join(root, 'source', 'opencode.db');
+      const destinationDb = path.join(root, 'destination', 'opencode.db');
+      const repoDb = path.join(repoRoot, 'data', 'opencode.db');
+      await fs.mkdir(path.dirname(sourceDb), { recursive: true });
+      await fs.mkdir(path.dirname(destinationDb), { recursive: true });
+      await fs.writeFile(sourceDb, 'new-database-content');
+      await fs.writeFile(`${sourceDb}-wal`, 'new-wal-content');
+      await fs.writeFile(`${sourceDb}-shm`, 'new-shm-content');
+
+      const sourcePlan = createPlan(repoRoot, path.join(root, 'source'), [
+        {
+          localPath: sourceDb,
+          repoPath: repoDb,
+          type: 'file',
+          isSecret: true,
+          isConfigFile: false,
+          preserveWhenMissing: true,
+          chunkLargeFiles: true,
+        },
+      ]);
+      await syncLocalToRepo(sourcePlan, null, { chunkOptions });
+
+      const shmPointer = JSON.parse(await fs.readFile(`${repoDb}-shm`, 'utf8')) as { id: string };
+      await fs.writeFile(
+        path.join(repoRoot, '.opencode-synced', 'chunks', 'v1', shmPointer.id, '000000.part'),
+        'xxxxx'
+      );
+      await fs.writeFile(destinationDb, 'old-database');
+      await fs.writeFile(`${destinationDb}-wal`, 'old-wal');
+      await fs.writeFile(`${destinationDb}-shm`, 'old-shm');
+      const destinationPlan = createPlan(repoRoot, path.join(root, 'destination'), [
+        {
+          localPath: destinationDb,
+          repoPath: repoDb,
+          type: 'file',
+          isSecret: true,
+          isConfigFile: false,
+          preserveWhenMissing: true,
+          chunkLargeFiles: true,
+        },
+      ]);
+
+      await expect(syncRepoToLocal(destinationPlan, null, { chunkOptions })).rejects.toThrow(
+        /SHA-256/u
+      );
+      await expect(fs.readFile(destinationDb, 'utf8')).resolves.toBe('old-database');
+      await expect(fs.readFile(`${destinationDb}-wal`, 'utf8')).resolves.toBe('old-wal');
+      await expect(fs.readFile(`${destinationDb}-shm`, 'utf8')).resolves.toBe('old-shm');
+    });
+  });
+
+  it('rolls back installed DB files when a later bundle rename fails', async () => {
+    await withTempDir(async (root) => {
+      const repoRoot = path.join(root, 'repo');
+      const repoDb = path.join(repoRoot, 'data', 'opencode.db');
+      const destinationDb = path.join(root, 'destination', 'opencode.db');
+      await fs.mkdir(path.dirname(repoDb), { recursive: true });
+      await fs.mkdir(path.dirname(destinationDb), { recursive: true });
+      await fs.writeFile(repoDb, 'new-db');
+      await fs.writeFile(`${repoDb}-wal`, 'new-wal');
+      await fs.writeFile(`${repoDb}-shm`, 'new-shm');
+      await fs.writeFile(destinationDb, 'old-db');
+      await fs.writeFile(`${destinationDb}-wal`, 'old-wal');
+      await fs.writeFile(`${destinationDb}-shm`, 'old-shm');
+      const plan = createPlan(repoRoot, path.join(root, 'destination'), [
+        {
+          localPath: destinationDb,
+          repoPath: repoDb,
+          type: 'file',
+          isSecret: true,
+          isConfigFile: false,
+          preserveWhenMissing: true,
+          chunkLargeFiles: true,
+        },
+      ]);
+
+      const originalRename = fs.rename.bind(fs);
+      let injected = false;
+      vi.spyOn(fs, 'rename').mockImplementation(async (source, destination) => {
+        if (
+          !injected &&
+          String(source).includes('.db-bundle-') &&
+          String(source).endsWith('opencode.db-shm') &&
+          destination === `${destinationDb}-shm`
+        ) {
+          injected = true;
+          throw new Error('injected bundle install failure');
+        }
+        return originalRename(source, destination);
+      });
+
+      await expect(syncRepoToLocal(plan, null, { chunkOptions })).rejects.toThrow(/injected/u);
+      await expect(fs.readFile(destinationDb, 'utf8')).resolves.toBe('old-db');
+      await expect(fs.readFile(`${destinationDb}-wal`, 'utf8')).resolves.toBe('old-wal');
+      await expect(fs.readFile(`${destinationDb}-shm`, 'utf8')).resolves.toBe('old-shm');
+    });
+  });
+
+  it('keeps an installed DB bundle when post-commit backup cleanup fails', async () => {
+    await withTempDir(async (root) => {
+      const repoRoot = path.join(root, 'repo');
+      const repoDb = path.join(repoRoot, 'data', 'opencode.db');
+      const destinationDb = path.join(root, 'destination', 'opencode.db');
+      await fs.mkdir(path.dirname(repoDb), { recursive: true });
+      await fs.mkdir(path.dirname(destinationDb), { recursive: true });
+      await fs.writeFile(repoDb, 'new-db');
+      await fs.writeFile(`${repoDb}-wal`, 'new-wal');
+      await fs.writeFile(`${repoDb}-shm`, 'new-shm');
+      await fs.writeFile(destinationDb, 'old-db');
+      await fs.writeFile(`${destinationDb}-wal`, 'old-wal');
+      await fs.writeFile(`${destinationDb}-shm`, 'old-shm');
+      const plan = createPlan(repoRoot, path.join(root, 'destination'), [
+        {
+          localPath: destinationDb,
+          repoPath: repoDb,
+          type: 'file',
+          isSecret: true,
+          isConfigFile: false,
+          preserveWhenMissing: true,
+          chunkLargeFiles: true,
+        },
+      ]);
+
+      const originalRm = fs.rm.bind(fs);
+      vi.spyOn(fs, 'rm').mockImplementation(async (target, options) => {
+        if (String(target).includes('.db-bundle-') && String(target).endsWith('.backup')) {
+          throw new Error('injected post-commit cleanup failure');
+        }
+        return originalRm(target, options);
+      });
+
+      await expect(syncRepoToLocal(plan, null, { chunkOptions })).resolves.toBeUndefined();
+      await expect(fs.readFile(destinationDb, 'utf8')).resolves.toBe('new-db');
+      await expect(fs.readFile(`${destinationDb}-wal`, 'utf8')).resolves.toBe('new-wal');
+      await expect(fs.readFile(`${destinationDb}-shm`, 'utf8')).resolves.toBe('new-shm');
     });
   });
 });

--- a/src/sync/apply.ts
+++ b/src/sync/apply.ts
@@ -1,6 +1,12 @@
-import { promises as fs } from 'node:fs';
+import crypto from 'node:crypto';
+import { promises as fs, type Stats } from 'node:fs';
 import path from 'node:path';
-
+import {
+  type ChunkOptions,
+  cleanupUnreferencedChunkStores,
+  copySessionFileFromRepo,
+  copySessionFileToRepo,
+} from './chunks.js';
 import {
   chmodIfExists,
   deepMerge,
@@ -44,9 +50,14 @@ interface ExtraPathManifest {
 
 export async function syncRepoToLocal(
   plan: SyncPlan,
-  overrides: Record<string, unknown> | null
+  overrides: Record<string, unknown> | null,
+  options: { chunkOptions?: ChunkOptions } = {}
 ): Promise<void> {
   for (const item of plan.items) {
+    if (item.chunkLargeFiles) {
+      await copyChunkableItemFromRepo(item, plan.repoRoot, options.chunkOptions);
+      continue;
+    }
     await copyItem(item.repoPath, item.localPath, item.type);
   }
 
@@ -61,7 +72,11 @@ export async function syncRepoToLocal(
 export async function syncLocalToRepo(
   plan: SyncPlan,
   overrides: Record<string, unknown> | null,
-  options: { overridesPath?: string; allowMcpSecrets?: boolean } = {}
+  options: {
+    overridesPath?: string;
+    allowMcpSecrets?: boolean;
+    chunkOptions?: ChunkOptions;
+  } = {}
 ): Promise<void> {
   const configItems = plan.items.filter((item) => item.isConfigFile);
   const sanitizedConfigs = new Map<string, Record<string, unknown>>();
@@ -103,11 +118,286 @@ export async function syncLocalToRepo(
       continue;
     }
 
+    if (item.chunkLargeFiles) {
+      await copyChunkableItemToRepo(item, plan.repoRoot, options.chunkOptions);
+      continue;
+    }
+
     await copyItem(item.localPath, item.repoPath, item.type, !item.preserveWhenMissing);
   }
 
   await writeExtraPathManifest(plan, plan.extraConfigs);
   await writeExtraPathManifest(plan, plan.extraSecrets);
+  await cleanupUnreferencedChunkStores(plan.repoRoot);
+}
+
+async function copyChunkableItemToRepo(
+  item: SyncItem,
+  repoRoot: string,
+  options: ChunkOptions = {}
+): Promise<void> {
+  if (!(await pathExists(item.localPath))) {
+    if (!item.preserveWhenMissing) await removePath(item.repoPath);
+    return;
+  }
+
+  if (item.type === 'file') {
+    await copyChunkableDbBundleToRepo(item.localPath, item.repoPath, repoRoot, options);
+    return;
+  }
+
+  const tempPath = `${item.repoPath}.tmp-${process.pid}-${crypto.randomUUID()}`;
+  try {
+    await copyChunkableDirectoryToRepo(item.localPath, tempPath, item.repoPath, repoRoot, options);
+    await replaceDirectory(tempPath, item.repoPath);
+  } catch (error) {
+    await removePath(tempPath);
+    throw error;
+  }
+}
+
+async function copyChunkableItemFromRepo(
+  item: SyncItem,
+  repoRoot: string,
+  options: ChunkOptions = {}
+): Promise<void> {
+  if (!(await pathExists(item.repoPath))) return;
+
+  if (item.type === 'file') {
+    await copyChunkableDbBundleFromRepo(item.repoPath, item.localPath, repoRoot, options);
+    return;
+  }
+
+  const tempPath = `${item.localPath}.tmp-${process.pid}-${crypto.randomUUID()}`;
+  try {
+    await copyChunkableDirectoryFromRepo(item.repoPath, tempPath, repoRoot, options);
+    await replaceDirectory(tempPath, item.localPath);
+  } catch (error) {
+    await removePath(tempPath);
+    throw error;
+  }
+}
+
+async function copyChunkableDbBundleToRepo(
+  sourceDbPath: string,
+  repoDbPath: string,
+  repoRoot: string,
+  options: ChunkOptions
+): Promise<void> {
+  const stageDir = path.join(
+    path.dirname(repoDbPath),
+    `.db-bundle-${process.pid}-${crypto.randomUUID()}`
+  );
+  const destinations = [
+    repoDbPath,
+    ...SESSION_DB_SIDECAR_SUFFIXES.map((suffix) => `${repoDbPath}${suffix}`),
+  ];
+  try {
+    await fs.mkdir(stageDir, { recursive: true, mode: 0o700 });
+    await copySessionFileToRepo(
+      sourceDbPath,
+      path.join(stageDir, path.basename(repoDbPath)),
+      repoRoot,
+      options,
+      repoDbPath
+    );
+    for (const suffix of SESSION_DB_SIDECAR_SUFFIXES) {
+      const sourcePath = `${sourceDbPath}${suffix}`;
+      if (!(await pathExists(sourcePath))) continue;
+      await copySessionFileToRepo(
+        sourcePath,
+        path.join(stageDir, `${path.basename(repoDbPath)}${suffix}`),
+        repoRoot,
+        options,
+        `${repoDbPath}${suffix}`
+      );
+    }
+    await replaceFileBundle(stageDir, destinations);
+  } catch (error) {
+    await removePath(stageDir);
+    throw error;
+  }
+}
+
+async function copyChunkableDbBundleFromRepo(
+  repoDbPath: string,
+  destinationDbPath: string,
+  repoRoot: string,
+  options: ChunkOptions
+): Promise<void> {
+  const stageDir = path.join(
+    path.dirname(destinationDbPath),
+    `.db-bundle-${process.pid}-${crypto.randomUUID()}`
+  );
+  const destinations = [
+    destinationDbPath,
+    ...SESSION_DB_SIDECAR_SUFFIXES.map((suffix) => `${destinationDbPath}${suffix}`),
+  ];
+  try {
+    await fs.mkdir(stageDir, { recursive: true, mode: 0o700 });
+    await copySessionFileFromRepo(
+      repoDbPath,
+      path.join(stageDir, path.basename(destinationDbPath)),
+      repoRoot,
+      options
+    );
+    for (const suffix of SESSION_DB_SIDECAR_SUFFIXES) {
+      const sourcePath = `${repoDbPath}${suffix}`;
+      if (!(await pathExists(sourcePath))) continue;
+      await copySessionFileFromRepo(
+        sourcePath,
+        path.join(stageDir, `${path.basename(destinationDbPath)}${suffix}`),
+        repoRoot,
+        options
+      );
+    }
+    await replaceFileBundle(stageDir, destinations);
+  } catch (error) {
+    await removePath(stageDir);
+    throw error;
+  }
+}
+
+async function replaceFileBundle(stageDir: string, destinations: string[]): Promise<void> {
+  const backupDir = `${stageDir}.backup`;
+  await fs.mkdir(backupDir, { recursive: true, mode: 0o700 });
+  const movedDestinations: string[] = [];
+  try {
+    for (const destination of destinations) {
+      if (!(await pathExists(destination))) continue;
+      await fs.rename(destination, path.join(backupDir, path.basename(destination)));
+    }
+
+    const stagedEntries = await fs.readdir(stageDir, { withFileTypes: true });
+    for (const entry of stagedEntries) {
+      if (!entry.isFile() || entry.isSymbolicLink()) {
+        throw new Error(`Invalid staged database bundle entry: ${entry.name}`);
+      }
+      const destination = destinations.find((candidate) => path.basename(candidate) === entry.name);
+      if (!destination) throw new Error(`Unexpected staged database bundle entry: ${entry.name}`);
+      await fs.mkdir(path.dirname(destination), { recursive: true });
+      await fs.rename(path.join(stageDir, entry.name), destination);
+      movedDestinations.push(destination);
+    }
+  } catch (error) {
+    for (const destination of movedDestinations) await removePath(destination);
+    const backups = await fs.readdir(backupDir).catch(() => []);
+    for (const name of backups) {
+      const destination = destinations.find((candidate) => path.basename(candidate) === name);
+      if (destination) await fs.rename(path.join(backupDir, name), destination);
+    }
+    await removePath(backupDir);
+    throw error;
+  }
+  await removePath(stageDir).catch(() => undefined);
+  await removePath(backupDir).catch(() => undefined);
+}
+
+async function copyChunkableDirectoryToRepo(
+  sourcePath: string,
+  destinationPath: string,
+  logicalRepoPath: string,
+  repoRoot: string,
+  options: ChunkOptions
+): Promise<void> {
+  const stat = await assertDirectory(sourcePath, 'session source directory');
+  await fs.mkdir(destinationPath, { recursive: true, mode: stat.mode & 0o777 });
+  const entries = await fs.readdir(sourcePath, { withFileTypes: true });
+  const entryNames = entries.map((entry) => entry.name).sort();
+
+  for (const entry of entries) {
+    const entrySource = path.join(sourcePath, entry.name);
+    const entryDestination = path.join(destinationPath, entry.name);
+    const entryLogicalPath = path.join(logicalRepoPath, entry.name);
+    if (entry.isSymbolicLink())
+      throw new Error(`Session source contains a symlink: ${entrySource}`);
+    if (entry.isDirectory()) {
+      await copyChunkableDirectoryToRepo(
+        entrySource,
+        entryDestination,
+        entryLogicalPath,
+        repoRoot,
+        options
+      );
+      continue;
+    }
+    if (!entry.isFile())
+      throw new Error(`Session source contains an unsupported entry: ${entrySource}`);
+    await copySessionFileToRepo(entrySource, entryDestination, repoRoot, options, entryLogicalPath);
+  }
+  await assertDirectoryUnchanged(sourcePath, stat, entryNames);
+  await chmodIfExists(destinationPath, stat.mode & 0o777);
+}
+
+async function copyChunkableDirectoryFromRepo(
+  sourcePath: string,
+  destinationPath: string,
+  repoRoot: string,
+  options: ChunkOptions
+): Promise<void> {
+  const stat = await assertDirectory(sourcePath, 'repository session directory');
+  await fs.mkdir(destinationPath, { recursive: true, mode: stat.mode & 0o777 });
+  const entries = await fs.readdir(sourcePath, { withFileTypes: true });
+  const entryNames = entries.map((entry) => entry.name).sort();
+
+  for (const entry of entries) {
+    const entrySource = path.join(sourcePath, entry.name);
+    const entryDestination = path.join(destinationPath, entry.name);
+    if (entry.isSymbolicLink())
+      throw new Error(`Repository session contains a symlink: ${entrySource}`);
+    if (entry.isDirectory()) {
+      await copyChunkableDirectoryFromRepo(entrySource, entryDestination, repoRoot, options);
+      continue;
+    }
+    if (!entry.isFile())
+      throw new Error(`Repository session has an unsupported entry: ${entrySource}`);
+    await copySessionFileFromRepo(entrySource, entryDestination, repoRoot, options);
+  }
+  await assertDirectoryUnchanged(sourcePath, stat, entryNames);
+  await chmodIfExists(destinationPath, stat.mode & 0o777);
+}
+
+async function replaceDirectory(sourcePath: string, destinationPath: string): Promise<void> {
+  const backupPath = `${destinationPath}.backup-${process.pid}-${crypto.randomUUID()}`;
+  const hadDestination = await pathExists(destinationPath);
+  if (hadDestination) await fs.rename(destinationPath, backupPath);
+  try {
+    await fs.mkdir(path.dirname(destinationPath), { recursive: true });
+    await fs.rename(sourcePath, destinationPath);
+    if (hadDestination) await removePath(backupPath);
+  } catch (error) {
+    if (hadDestination && !(await pathExists(destinationPath))) {
+      await fs.rename(backupPath, destinationPath);
+    }
+    throw error;
+  }
+}
+
+async function assertDirectory(directoryPath: string, label: string): Promise<Stats> {
+  const stat = await fs.lstat(directoryPath);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`${label} is not a regular directory: ${directoryPath}`);
+  }
+  return stat;
+}
+
+async function assertDirectoryUnchanged(
+  directoryPath: string,
+  initialStat: Stats,
+  initialNames: string[]
+): Promise<void> {
+  const finalStat = await assertDirectory(directoryPath, 'session directory');
+  const finalNames = (await fs.readdir(directoryPath)).sort();
+  if (
+    finalStat.mtimeMs !== initialStat.mtimeMs ||
+    finalStat.ctimeMs !== initialStat.ctimeMs ||
+    finalStat.dev !== initialStat.dev ||
+    finalStat.ino !== initialStat.ino ||
+    finalNames.length !== initialNames.length ||
+    finalNames.some((name, index) => name !== initialNames[index])
+  ) {
+    throw new Error(`Session directory changed while it was being copied: ${directoryPath}`);
+  }
 }
 
 async function copyItem(

--- a/src/sync/chunks.test.ts
+++ b/src/sync/chunks.test.ts
@@ -1,0 +1,305 @@
+import crypto from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  cleanupUnreferencedChunkStores,
+  copySessionFileFromRepo,
+  copySessionFileToRepo,
+  createChunkId,
+} from './chunks.js';
+
+const roots: string[] = [];
+const options = {
+  thresholdBytes: 8,
+  chunkBytes: 5,
+  maxFileBytes: 128,
+  maxChunks: 32,
+  bufferBytes: 3,
+};
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe('session chunk storage', () => {
+  it('round-trips a large file with strict metadata and its original mode', async () => {
+    const fixture = await createFixture();
+    const content = Buffer.from('large-session-payload');
+    await fs.writeFile(fixture.source, content, { mode: 0o600 });
+    await fs.chmod(fixture.source, 0o600);
+
+    await copySessionFileToRepo(fixture.source, fixture.repoFile, fixture.repo, options);
+
+    const pointer = JSON.parse(await fs.readFile(fixture.repoFile, 'utf8')) as Record<
+      string,
+      unknown
+    >;
+    expect(pointer).toMatchObject({
+      format: 'opencode-synced-chunks',
+      version: 1,
+      size: content.length,
+      mode: 0o600,
+      chunkSize: 5,
+      chunkCount: Math.ceil(content.length / 5),
+      sha256: crypto.createHash('sha256').update(content).digest('hex'),
+    });
+
+    await fs.chmod(fixture.repoFile, 0o644);
+    await copySessionFileFromRepo(fixture.repoFile, fixture.destination, fixture.repo, options);
+    expect(await fs.readFile(fixture.destination)).toEqual(content);
+    expect((await fs.stat(fixture.destination)).mode & 0o777).toBe(0o600);
+  });
+
+  it('leaves an existing destination intact when a chunk is missing', async () => {
+    const fixture = await createChunkedFixture();
+    await fs.mkdir(path.dirname(fixture.destination), { recursive: true });
+    await fs.writeFile(fixture.destination, 'keep-me');
+    const store = await getStorePath(fixture.repoFile, fixture.repo);
+    await fs.rm(path.join(store, '000001.part'));
+
+    await expect(
+      copySessionFileFromRepo(fixture.repoFile, fixture.destination, fixture.repo, options)
+    ).rejects.toThrow(/missing, extra, or invalid/u);
+    expect(await fs.readFile(fixture.destination, 'utf8')).toBe('keep-me');
+  });
+
+  it('rejects extra and non-numeric chunk entries', async () => {
+    const fixture = await createChunkedFixture();
+    const store = await getStorePath(fixture.repoFile, fixture.repo);
+    await fs.writeFile(path.join(store, 'notes.txt'), 'unexpected');
+
+    await expect(
+      copySessionFileFromRepo(fixture.repoFile, fixture.destination, fixture.repo, options)
+    ).rejects.toThrow(/missing, extra, or invalid/u);
+  });
+
+  it('rejects same-size corrupt chunks without replacing the destination', async () => {
+    const fixture = await createChunkedFixture();
+    await fs.mkdir(path.dirname(fixture.destination), { recursive: true });
+    await fs.writeFile(fixture.destination, 'original');
+    const store = await getStorePath(fixture.repoFile, fixture.repo);
+    await fs.writeFile(path.join(store, '000000.part'), 'xxxxx');
+
+    await expect(
+      copySessionFileFromRepo(fixture.repoFile, fixture.destination, fixture.repo, options)
+    ).rejects.toThrow(/SHA-256/u);
+    expect(await fs.readFile(fixture.destination, 'utf8')).toBe('original');
+  });
+
+  it('does not reuse a same-size corrupt content-addressed store', async () => {
+    const fixture = await createChunkedFixture();
+    const store = await getStorePath(fixture.repoFile, fixture.repo);
+    await fs.writeFile(path.join(store, '000000.part'), 'xxxxx');
+
+    await expect(
+      copySessionFileToRepo(fixture.source, fixture.repoFile, fixture.repo, options)
+    ).rejects.toThrow(/SHA-256/u);
+  });
+
+  it('rejects a pointer copied to another repository path', async () => {
+    const fixture = await createChunkedFixture();
+    const copiedPointer = path.join(fixture.repo, 'data', 'storage', 'message', 'other.json');
+    await fs.copyFile(fixture.repoFile, copiedPointer);
+
+    await expect(
+      copySessionFileFromRepo(copiedPointer, fixture.destination, fixture.repo, options)
+    ).rejects.toThrow(/does not match its repository path/u);
+  });
+
+  it('rejects malformed and oversized pointer markers instead of treating them as legacy files', async () => {
+    const fixture = await createFixture();
+    await fs.writeFile(fixture.repoFile, '{"format":"opencode-synced-chunks"');
+    await expect(
+      copySessionFileFromRepo(fixture.repoFile, fixture.destination, fixture.repo, options)
+    ).rejects.toThrow(/valid JSON/u);
+
+    await fs.writeFile(
+      fixture.repoFile,
+      `{"format":"opencode-synced-chunks"}${' '.repeat(17 * 1024)}`
+    );
+    await expect(
+      copySessionFileFromRepo(fixture.repoFile, fixture.destination, fixture.repo, options)
+    ).rejects.toThrow(/size limit/u);
+  });
+
+  it('keeps ordinary small session files byte-for-byte without a pointer', async () => {
+    const fixture = await createFixture();
+    await fs.writeFile(fixture.source, 'small', { mode: 0o640 });
+    await fs.chmod(fixture.source, 0o640);
+
+    await copySessionFileToRepo(fixture.source, fixture.repoFile, fixture.repo, options);
+    expect(await fs.readFile(fixture.repoFile, 'utf8')).toBe('small');
+
+    await copySessionFileFromRepo(fixture.repoFile, fixture.destination, fixture.repo, options);
+    expect(await fs.readFile(fixture.destination, 'utf8')).toBe('small');
+    expect((await fs.stat(fixture.destination)).mode & 0o777).toBe(0o640);
+  });
+
+  it('reads a legacy plain file even when it is now above the chunk threshold', async () => {
+    const fixture = await createFixture();
+    await fs.writeFile(fixture.repoFile, 'legacy-plain-session');
+
+    await copySessionFileFromRepo(fixture.repoFile, fixture.destination, fixture.repo, options);
+    expect(await fs.readFile(fixture.destination, 'utf8')).toBe('legacy-plain-session');
+  });
+
+  it('derives the same chunk ID from POSIX and Windows separators', () => {
+    const sha256 = 'e'.repeat(64);
+    expect(createChunkId('data/storage/message/message.json', sha256)).toBe(
+      createChunkId('data\\storage\\message\\message.json', sha256)
+    );
+  });
+
+  it('removes only unreferenced content-addressed stores', async () => {
+    const fixture = await createChunkedFixture();
+    const referencedStore = await getStorePath(fixture.repoFile, fixture.repo);
+    const orphanId = 'a'.repeat(64);
+    const orphanStore = path.join(fixture.repo, '.opencode-synced', 'chunks', 'v1', orphanId);
+    const unexpectedStore = path.join(fixture.repo, '.opencode-synced', 'chunks', 'v1', 'manual');
+    await fs.mkdir(orphanStore, { recursive: true });
+    await fs.mkdir(unexpectedStore, { recursive: true });
+
+    await cleanupUnreferencedChunkStores(fixture.repo);
+    expect(await exists(referencedStore)).toBe(true);
+    expect(await exists(orphanStore)).toBe(false);
+    expect(await exists(unexpectedStore)).toBe(true);
+  });
+
+  it('does not clean a colliding namespace without the ownership marker', async () => {
+    const fixture = await createFixture();
+    const collidingStore = path.join(
+      fixture.repo,
+      '.opencode-synced',
+      'chunks',
+      'v1',
+      'b'.repeat(64)
+    );
+    await fs.mkdir(collidingStore, { recursive: true });
+    await fs.writeFile(path.join(collidingStore, 'user-data'), 'keep');
+
+    await cleanupUnreferencedChunkStores(fixture.repo);
+    expect(await fs.readFile(path.join(collidingStore, 'user-data'), 'utf8')).toBe('keep');
+  });
+
+  it('refuses to write into a colliding unowned namespace', async () => {
+    const fixture = await createFixture();
+    await fs.writeFile(fixture.source, '0123456789abcdef');
+    const collision = path.join(fixture.repo, '.opencode-synced', 'chunks', 'user-data');
+    await fs.mkdir(path.dirname(collision), { recursive: true });
+    await fs.writeFile(collision, 'keep');
+
+    await expect(
+      copySessionFileToRepo(fixture.source, fixture.repoFile, fixture.repo, options)
+    ).rejects.toThrow(/unowned data/u);
+    expect(await fs.readFile(collision, 'utf8')).toBe('keep');
+  });
+
+  it('fails cleanup closed when a chunk pointer is corrupt', async () => {
+    const fixture = await createChunkedFixture();
+    const orphanStore = path.join(fixture.repo, '.opencode-synced', 'chunks', 'v1', 'c'.repeat(64));
+    await fs.mkdir(orphanStore, { recursive: true });
+    await fs.writeFile(fixture.repoFile, '{"format":"opencode-synced-chunks","version":1}');
+
+    await expect(cleanupUnreferencedChunkStores(fixture.repo)).rejects.toThrow(/pointer/u);
+    expect(await exists(orphanStore)).toBe(true);
+  });
+
+  it('rejects an ancestor symlink before cleanup can touch external data', async () => {
+    const fixture = await createFixture();
+    const external = path.join(fixture.root, 'external');
+    const externalStore = path.join(external, 'chunks', 'v1', 'd'.repeat(64));
+    await fs.mkdir(externalStore, { recursive: true });
+    await fs.writeFile(
+      path.join(external, 'chunks', 'OWNER.json'),
+      '{"format":"opencode-synced-chunk-store","version":1}\n'
+    );
+    await fs.writeFile(path.join(externalStore, 'user-data'), 'keep');
+    await fs.mkdir(fixture.repo, { recursive: true });
+    await fs.symlink(external, path.join(fixture.repo, '.opencode-synced'));
+
+    await expect(cleanupUnreferencedChunkStores(fixture.repo)).rejects.toThrow(/symlink/u);
+    expect(await fs.readFile(path.join(externalStore, 'user-data'), 'utf8')).toBe('keep');
+  });
+
+  it('fails safely when the source shrinks during streaming', async () => {
+    const fixture = await createFixture();
+    const largeOptions = {
+      thresholdBytes: 1,
+      chunkBytes: 1024 * 1024,
+      maxFileBytes: 32 * 1024 * 1024,
+      maxChunks: 32,
+      bufferBytes: 4096,
+    };
+    await fs.writeFile(fixture.source, Buffer.alloc(16 * 1024 * 1024, 7));
+
+    const truncate = new Promise<void>((resolve) => {
+      setTimeout(async () => {
+        await fs.truncate(fixture.source, 16);
+        resolve();
+      }, 1);
+    });
+    await expect(
+      copySessionFileToRepo(fixture.source, fixture.repoFile, fixture.repo, largeOptions)
+    ).rejects.toThrow(/shrank|changed/u);
+    await truncate;
+    expect(await exists(fixture.repoFile)).toBe(false);
+  });
+
+  it('does not copy a file unchunked when it grows after the routing stat', async () => {
+    const fixture = await createFixture();
+    await fs.writeFile(fixture.source, 'small');
+    const initialStat = await fs.lstat(fixture.source);
+    vi.spyOn(fs, 'lstat').mockImplementationOnce(async () => {
+      await fs.writeFile(fixture.source, '0123456789abcdef');
+      return initialStat;
+    });
+
+    await expect(
+      copySessionFileToRepo(fixture.source, fixture.repoFile, fixture.repo, options)
+    ).rejects.toThrow(/changed/u);
+    expect(await exists(fixture.repoFile)).toBe(false);
+  });
+});
+
+async function createFixture(): Promise<{
+  root: string;
+  repo: string;
+  source: string;
+  repoFile: string;
+  destination: string;
+}> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'opencode-synced-chunks-'));
+  roots.push(root);
+  const repo = path.join(root, 'repo');
+  const source = path.join(root, 'local', 'message.json');
+  const repoFile = path.join(repo, 'data', 'storage', 'message', 'message.json');
+  const destination = path.join(root, 'destination', 'message.json');
+  await fs.mkdir(path.dirname(source), { recursive: true });
+  await fs.mkdir(path.dirname(repoFile), { recursive: true });
+  return { root, repo, source, repoFile, destination };
+}
+
+async function createChunkedFixture(): Promise<Awaited<ReturnType<typeof createFixture>>> {
+  const fixture = await createFixture();
+  await fs.writeFile(fixture.source, '0123456789abcdef');
+  await copySessionFileToRepo(fixture.source, fixture.repoFile, fixture.repo, options);
+  return fixture;
+}
+
+async function getStorePath(repoFile: string, repoRoot: string): Promise<string> {
+  const pointer = JSON.parse(await fs.readFile(repoFile, 'utf8')) as { id: string };
+  return path.join(repoRoot, '.opencode-synced', 'chunks', 'v1', pointer.id);
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/sync/chunks.ts
+++ b/src/sync/chunks.ts
@@ -1,0 +1,744 @@
+import crypto from 'node:crypto';
+import { promises as fs, constants as fsConstants, type Stats } from 'node:fs';
+import path from 'node:path';
+
+import { pathExists } from './config.js';
+
+const POINTER_FORMAT = 'opencode-synced-chunks';
+const POINTER_VERSION = 1;
+const STORE_OWNER_FORMAT = 'opencode-synced-chunk-store';
+const STORE_OWNER_FILE = 'OWNER.json';
+const STORE_OWNER_CONTENT = `${JSON.stringify({
+  format: STORE_OWNER_FORMAT,
+  version: POINTER_VERSION,
+})}\n`;
+const STORE_ROOT_RELATIVE_PATH = path.join('.opencode-synced', 'chunks');
+const STORE_RELATIVE_PATH = path.join('.opencode-synced', 'chunks', 'v1');
+const POINTER_LIMIT = 16 * 1024;
+const MAX_POINTER_SCAN_ENTRIES = 100_000;
+const MAX_POINTER_SCAN_DEPTH = 64;
+const STALE_TEMP_AGE_MS = 60 * 60 * 1000;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
+const CHUNK_NAME_PATTERN = /^\d{6}\.part$/u;
+
+export interface ChunkOptions {
+  thresholdBytes?: number;
+  chunkBytes?: number;
+  maxFileBytes?: number;
+  maxChunks?: number;
+  bufferBytes?: number;
+}
+
+interface ResolvedChunkOptions {
+  thresholdBytes: number;
+  chunkBytes: number;
+  maxFileBytes: number;
+  maxChunks: number;
+  bufferBytes: number;
+}
+
+interface ChunkPointer {
+  format: typeof POINTER_FORMAT;
+  version: typeof POINTER_VERSION;
+  id: string;
+  sha256: string;
+  size: number;
+  mode: number;
+  chunkSize: number;
+  chunkCount: number;
+}
+
+const DEFAULT_OPTIONS: ResolvedChunkOptions = {
+  thresholdBytes: 50 * 1024 * 1024,
+  chunkBytes: 40 * 1024 * 1024,
+  maxFileBytes: 4 * 1024 * 1024 * 1024,
+  maxChunks: 128,
+  bufferBytes: 1024 * 1024,
+};
+
+export async function copySessionFileToRepo(
+  sourcePath: string,
+  repoPath: string,
+  repoRoot: string,
+  options: ChunkOptions = {},
+  logicalRepoPath = repoPath
+): Promise<void> {
+  const resolved = resolveOptions(options);
+  const sourceStat = await assertRegularFile(sourcePath, 'session source');
+  if (sourceStat.size > resolved.maxFileBytes) {
+    throw new Error(
+      `Session file exceeds the ${resolved.maxFileBytes}-byte safety limit: ${sourcePath}`
+    );
+  }
+
+  if (sourceStat.size <= resolved.thresholdBytes) {
+    await copyRegularFileAtomic(sourcePath, repoPath, sourceStat.mode & 0o777, sourceStat);
+    return;
+  }
+
+  const chunkCount = Math.ceil(sourceStat.size / resolved.chunkBytes);
+  if (chunkCount > resolved.maxChunks) {
+    throw new Error(`Session file requires ${chunkCount} chunks, exceeding the safety limit.`);
+  }
+
+  const relativePath = assertRepoRelativePath(repoRoot, logicalRepoPath);
+  await ensureOwnedChunkStore(repoRoot);
+  const tempStore = path.join(
+    repoRoot,
+    STORE_RELATIVE_PATH,
+    `.tmp-${process.pid}-${crypto.randomUUID()}`
+  );
+  await fs.mkdir(tempStore, { recursive: true, mode: 0o700 });
+
+  let finalStore = '';
+  try {
+    const digest = await splitFile(sourcePath, tempStore, sourceStat, resolved);
+    const id = createChunkId(relativePath, digest);
+    finalStore = chunkStorePath(repoRoot, id);
+
+    await fs.mkdir(path.dirname(finalStore), { recursive: true, mode: 0o700 });
+    if (await pathExists(finalStore)) {
+      await validateChunkDirectory(finalStore, {
+        format: POINTER_FORMAT,
+        version: POINTER_VERSION,
+        id,
+        sha256: digest,
+        size: sourceStat.size,
+        mode: sourceStat.mode & 0o777,
+        chunkSize: resolved.chunkBytes,
+        chunkCount,
+      });
+      await validateChunkContent(finalStore, digest, sourceStat.size, resolved.bufferBytes);
+      await fs.rm(tempStore, { recursive: true, force: true });
+    } else {
+      await fs.rename(tempStore, finalStore);
+    }
+
+    const pointer: ChunkPointer = {
+      format: POINTER_FORMAT,
+      version: POINTER_VERSION,
+      id,
+      sha256: digest,
+      size: sourceStat.size,
+      mode: sourceStat.mode & 0o777,
+      chunkSize: resolved.chunkBytes,
+      chunkCount,
+    };
+    await writeFileAtomic(repoPath, `${JSON.stringify(pointer)}\n`, sourceStat.mode & 0o777);
+  } catch (error) {
+    await fs.rm(tempStore, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+export async function copySessionFileFromRepo(
+  repoPath: string,
+  destinationPath: string,
+  repoRoot: string,
+  options: ChunkOptions = {}
+): Promise<void> {
+  const resolved = resolveOptions(options);
+  const sourceStat = await assertRegularFile(repoPath, 'repository session file');
+  const pointer = await readPointer(repoPath, sourceStat.size);
+  if (!pointer) {
+    if (sourceStat.size > resolved.maxFileBytes) {
+      throw new Error(`Repository session file exceeds the safety limit: ${repoPath}`);
+    }
+    await copyRegularFileAtomic(repoPath, destinationPath, sourceStat.mode & 0o777, sourceStat);
+    return;
+  }
+
+  const relativePath = assertRepoRelativePath(repoRoot, repoPath);
+  const expectedId = createChunkId(relativePath, pointer.sha256);
+  if (pointer.id !== expectedId) {
+    throw new Error('Chunk pointer identifier does not match its repository path.');
+  }
+
+  const storePath = chunkStorePath(repoRoot, pointer.id);
+  await assertSafeStorePath(repoRoot, storePath);
+  await validateChunkDirectory(storePath, pointer);
+  await reconstructFileAtomic(storePath, destinationPath, pointer, resolved.bufferBytes);
+}
+
+export async function cleanupUnreferencedChunkStores(repoRoot: string): Promise<void> {
+  await assertSafeStorePath(repoRoot, path.join(repoRoot, STORE_RELATIVE_PATH));
+  if (!(await hasOwnedChunkStore(repoRoot))) return;
+  const storeRoot = path.join(repoRoot, STORE_RELATIVE_PATH);
+  if (!(await pathExists(storeRoot))) return;
+
+  const referenced = new Set<string>();
+  const scanState = { entries: 0 };
+  for (const candidate of [
+    path.join(repoRoot, 'data', 'opencode.db'),
+    path.join(repoRoot, 'data', 'opencode.db-wal'),
+    path.join(repoRoot, 'data', 'opencode.db-shm'),
+    path.join(repoRoot, 'data', 'storage', 'message'),
+  ]) {
+    await collectKnownPointerIds(candidate, referenced, scanState, 0);
+  }
+  const entries = await fs.readdir(storeRoot, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isDirectory() && /^\.tmp-\d+-[a-f0-9-]+$/u.test(entry.name)) {
+      const tempPath = path.join(storeRoot, entry.name);
+      const tempStat = await fs.lstat(tempPath);
+      if (Date.now() - tempStat.mtimeMs >= STALE_TEMP_AGE_MS) {
+        await removeOwnedStoreDirectory(repoRoot, tempPath);
+      }
+      continue;
+    }
+    if (!entry.isDirectory() || !SHA256_PATTERN.test(entry.name)) continue;
+    if (referenced.has(entry.name)) continue;
+    await removeOwnedStoreDirectory(repoRoot, path.join(storeRoot, entry.name));
+  }
+}
+
+export function isChunkStorePath(repoRoot: string, candidatePath: string): boolean {
+  const storeRoot = path.resolve(repoRoot, STORE_RELATIVE_PATH);
+  const resolved = path.resolve(candidatePath);
+  return resolved === storeRoot || resolved.startsWith(`${storeRoot}${path.sep}`);
+}
+
+function resolveOptions(options: ChunkOptions): ResolvedChunkOptions {
+  const resolved = { ...DEFAULT_OPTIONS, ...options };
+  for (const [name, value] of Object.entries(resolved)) {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      throw new Error(`Invalid chunk option ${name}.`);
+    }
+  }
+  if (resolved.chunkBytes >= 100 * 1024 * 1024) {
+    throw new Error("Chunk size must remain below GitHub's 100 MiB file limit.");
+  }
+  if (resolved.chunkBytes > resolved.maxFileBytes) {
+    throw new Error('Chunk size cannot exceed the maximum file size.');
+  }
+  return resolved;
+}
+
+async function splitFile(
+  sourcePath: string,
+  destinationDir: string,
+  expectedStat: Stats,
+  options: ResolvedChunkOptions
+): Promise<string> {
+  const expectedSize = expectedStat.size;
+  const source = await fs.open(sourcePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  const hash = crypto.createHash('sha256');
+  const buffer = Buffer.allocUnsafe(Math.min(options.bufferBytes, options.chunkBytes));
+  let offset = 0;
+  let chunkIndex = 0;
+  let chunkHandle: Awaited<ReturnType<typeof fs.open>> | null = null;
+  let bytesInChunk = 0;
+
+  try {
+    while (offset < expectedSize) {
+      if (!chunkHandle || bytesInChunk === options.chunkBytes) {
+        await chunkHandle?.close();
+        chunkHandle = await fs.open(
+          path.join(destinationDir, chunkName(chunkIndex)),
+          fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY,
+          0o600
+        );
+        chunkIndex += 1;
+        bytesInChunk = 0;
+      }
+
+      const remainingFile = expectedSize - offset;
+      const remainingChunk = options.chunkBytes - bytesInChunk;
+      const length = Math.min(buffer.length, remainingFile, remainingChunk);
+      const { bytesRead } = await source.read(buffer, 0, length, offset);
+      if (bytesRead === 0) {
+        throw new Error(`Session source shrank while it was being chunked: ${sourcePath}`);
+      }
+      const slice = buffer.subarray(0, bytesRead);
+      await writeAll(chunkHandle, slice);
+      hash.update(slice);
+      offset += bytesRead;
+      bytesInChunk += bytesRead;
+    }
+    await chunkHandle?.close();
+    chunkHandle = null;
+
+    const finalStat = await source.stat();
+    if (
+      finalStat.size !== expectedSize ||
+      finalStat.mtimeMs !== expectedStat.mtimeMs ||
+      finalStat.ctimeMs !== expectedStat.ctimeMs ||
+      finalStat.dev !== expectedStat.dev ||
+      finalStat.ino !== expectedStat.ino
+    ) {
+      throw new Error(`Session source changed while it was being chunked: ${sourcePath}`);
+    }
+    const expectedChunks = Math.ceil(expectedSize / options.chunkBytes);
+    if (chunkIndex !== expectedChunks) {
+      throw new Error('Chunk writer produced an unexpected number of chunks.');
+    }
+    return hash.digest('hex');
+  } finally {
+    await chunkHandle?.close();
+    await source.close();
+  }
+}
+
+async function reconstructFileAtomic(
+  storePath: string,
+  destinationPath: string,
+  pointer: ChunkPointer,
+  bufferBytes: number
+): Promise<void> {
+  await fs.mkdir(path.dirname(destinationPath), { recursive: true });
+  const tempPath = `${destinationPath}.tmp-${process.pid}-${crypto.randomUUID()}`;
+  const destination = await fs.open(
+    tempPath,
+    fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY,
+    0o600
+  );
+  const hash = crypto.createHash('sha256');
+  const buffer = Buffer.allocUnsafe(bufferBytes);
+  let total = 0;
+
+  try {
+    for (let index = 0; index < pointer.chunkCount; index += 1) {
+      const chunkPath = path.join(storePath, chunkName(index));
+      const chunk = await fs.open(chunkPath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+      try {
+        let position = 0;
+        while (true) {
+          const { bytesRead } = await chunk.read(buffer, 0, buffer.length, position);
+          if (bytesRead === 0) break;
+          const slice = buffer.subarray(0, bytesRead);
+          await writeAll(destination, slice);
+          hash.update(slice);
+          position += bytesRead;
+          total += bytesRead;
+          if (total > pointer.size) throw new Error('Chunk data exceeds the declared size.');
+        }
+      } finally {
+        await chunk.close();
+      }
+    }
+    await destination.sync();
+    await destination.close();
+
+    if (total !== pointer.size || hash.digest('hex') !== pointer.sha256) {
+      throw new Error('Chunk data failed size or SHA-256 validation.');
+    }
+    await fs.chmod(tempPath, pointer.mode);
+    await replaceFile(tempPath, destinationPath);
+  } catch (error) {
+    await destination.close().catch(() => undefined);
+    await fs.rm(tempPath, { force: true });
+    throw error;
+  }
+}
+
+async function validateChunkDirectory(storePath: string, pointer: ChunkPointer): Promise<void> {
+  const stat = await fs.lstat(storePath).catch(() => null);
+  if (!stat?.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`Chunk store is missing or is not a regular directory: ${pointer.id}`);
+  }
+  const entries = await fs.readdir(storePath, { withFileTypes: true });
+  const expectedNames = Array.from({ length: pointer.chunkCount }, (_, index) => chunkName(index));
+  const actualNames = entries.map((entry) => entry.name).sort();
+  if (
+    actualNames.length !== expectedNames.length ||
+    actualNames.some((name, index) => name !== expectedNames[index])
+  ) {
+    throw new Error(`Chunk store has missing, extra, or invalid entries: ${pointer.id}`);
+  }
+
+  for (let index = 0; index < entries.length; index += 1) {
+    const name = expectedNames[index] as string;
+    if (!CHUNK_NAME_PATTERN.test(name)) throw new Error(`Invalid chunk name: ${name}`);
+    const chunkStat = await fs.lstat(path.join(storePath, name));
+    if (!chunkStat.isFile() || chunkStat.isSymbolicLink()) {
+      throw new Error(`Chunk is not a regular file: ${name}`);
+    }
+    const expectedSize =
+      index === pointer.chunkCount - 1
+        ? pointer.size - pointer.chunkSize * (pointer.chunkCount - 1)
+        : pointer.chunkSize;
+    if (chunkStat.size !== expectedSize) {
+      throw new Error(`Chunk has the wrong size: ${name}`);
+    }
+  }
+}
+
+async function validateChunkContent(
+  storePath: string,
+  expectedSha256: string,
+  expectedSize: number,
+  bufferBytes: number
+): Promise<void> {
+  const hash = crypto.createHash('sha256');
+  const entries = (await fs.readdir(storePath)).sort();
+  const buffer = Buffer.allocUnsafe(bufferBytes);
+  let total = 0;
+  for (const name of entries) {
+    const chunk = await fs.open(
+      path.join(storePath, name),
+      fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW
+    );
+    try {
+      let position = 0;
+      while (true) {
+        const { bytesRead } = await chunk.read(buffer, 0, buffer.length, position);
+        if (bytesRead === 0) break;
+        hash.update(buffer.subarray(0, bytesRead));
+        position += bytesRead;
+        total += bytesRead;
+        if (total > expectedSize) throw new Error('Existing chunk store exceeds expected size.');
+      }
+    } finally {
+      await chunk.close();
+    }
+  }
+  if (total !== expectedSize || hash.digest('hex') !== expectedSha256) {
+    throw new Error('Existing chunk store failed SHA-256 validation.');
+  }
+}
+
+async function readPointer(filePath: string, fileSize: number): Promise<ChunkPointer | null> {
+  if (fileSize > POINTER_LIMIT) {
+    const handle = await fs.open(filePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+    try {
+      const prefix = Buffer.alloc(POINTER_LIMIT);
+      const { bytesRead } = await handle.read(prefix, 0, prefix.length, 0);
+      if (prefix.subarray(0, bytesRead).toString('utf8').includes(POINTER_FORMAT)) {
+        throw new Error('Chunk pointer exceeds the metadata size limit.');
+      }
+    } finally {
+      await handle.close();
+    }
+    return null;
+  }
+  const content = await fs.readFile(filePath, 'utf8');
+  let value: unknown;
+  try {
+    value = JSON.parse(content);
+  } catch {
+    if (content.includes(POINTER_FORMAT)) throw new Error('Chunk pointer is not valid JSON.');
+    return null;
+  }
+  if (!isRecord(value) || value.format !== POINTER_FORMAT) return null;
+
+  const exactKeys = [
+    'chunkCount',
+    'chunkSize',
+    'format',
+    'id',
+    'mode',
+    'sha256',
+    'size',
+    'version',
+  ];
+  const keys = Object.keys(value).sort();
+  if (keys.length !== exactKeys.length || keys.some((key, index) => key !== exactKeys[index])) {
+    throw new Error('Chunk pointer has unknown or missing fields.');
+  }
+  const pointer = value as unknown as ChunkPointer;
+  if (
+    pointer.version !== POINTER_VERSION ||
+    !SHA256_PATTERN.test(pointer.id) ||
+    !SHA256_PATTERN.test(pointer.sha256) ||
+    !Number.isSafeInteger(pointer.size) ||
+    pointer.size <= 0 ||
+    pointer.size > DEFAULT_OPTIONS.maxFileBytes ||
+    !Number.isSafeInteger(pointer.mode) ||
+    pointer.mode < 0 ||
+    pointer.mode > 0o777 ||
+    !Number.isSafeInteger(pointer.chunkSize) ||
+    pointer.chunkSize <= 0 ||
+    pointer.chunkSize >= 100 * 1024 * 1024 ||
+    !Number.isSafeInteger(pointer.chunkCount) ||
+    pointer.chunkCount <= 0 ||
+    pointer.chunkCount > DEFAULT_OPTIONS.maxChunks ||
+    pointer.chunkCount !== Math.ceil(pointer.size / pointer.chunkSize)
+  ) {
+    throw new Error('Chunk pointer metadata is invalid or exceeds safety limits.');
+  }
+  return pointer;
+}
+
+async function collectKnownPointerIds(
+  currentPath: string,
+  ids: Set<string>,
+  state: { entries: number },
+  depth: number
+): Promise<void> {
+  if (depth > MAX_POINTER_SCAN_DEPTH) {
+    throw new Error('Refusing chunk cleanup because session storage is nested too deeply.');
+  }
+  const currentStat = await fs.lstat(currentPath).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === 'ENOENT') return null;
+    throw error;
+  });
+  if (!currentStat) return;
+  if (currentStat.isSymbolicLink()) {
+    throw new Error(
+      `Refusing chunk cleanup because session storage contains a symlink: ${currentPath}`
+    );
+  }
+  if (currentStat.isFile()) {
+    await collectPointerId(currentPath, currentStat.size, ids);
+    return;
+  }
+  if (!currentStat.isDirectory()) return;
+
+  const entries = await fs.readdir(currentPath, { withFileTypes: true });
+  for (const entry of entries) {
+    state.entries += 1;
+    if (state.entries > MAX_POINTER_SCAN_ENTRIES) {
+      throw new Error('Refusing chunk cleanup because session storage exceeds the scan limit.');
+    }
+    const entryPath = path.join(currentPath, entry.name);
+    if (entry.isSymbolicLink()) {
+      throw new Error(
+        `Refusing chunk cleanup because session storage contains a symlink: ${entryPath}`
+      );
+    }
+    await collectKnownPointerIds(entryPath, ids, state, depth + 1);
+  }
+}
+
+async function collectPointerId(filePath: string, size: number, ids: Set<string>): Promise<void> {
+  if (size > POINTER_LIMIT) {
+    const handle = await fs.open(filePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+    try {
+      const prefix = Buffer.alloc(512);
+      const { bytesRead } = await handle.read(prefix, 0, prefix.length, 0);
+      if (prefix.subarray(0, bytesRead).toString('utf8').includes(POINTER_FORMAT)) {
+        throw new Error(`Refusing chunk cleanup because a pointer is oversized: ${filePath}`);
+      }
+    } finally {
+      await handle.close();
+    }
+    return;
+  }
+  const content = await fs.readFile(filePath, 'utf8').catch(() => '');
+  let value: unknown;
+  try {
+    value = JSON.parse(content) as unknown;
+  } catch {
+    if (content.includes(POINTER_FORMAT)) {
+      throw new Error(`Refusing chunk cleanup because a pointer is corrupt: ${filePath}`);
+    }
+    return;
+  }
+  if (!isRecord(value) || value.format !== POINTER_FORMAT) return;
+  const pointer = await readPointer(filePath, size);
+  if (!pointer) throw new Error(`Refusing chunk cleanup because a pointer is corrupt: ${filePath}`);
+  ids.add(pointer.id);
+}
+
+async function removeOwnedStoreDirectory(repoRoot: string, directoryPath: string): Promise<void> {
+  await assertSafeStorePath(repoRoot, directoryPath);
+  const stat = await fs.lstat(directoryPath);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`Refusing to remove an invalid chunk store entry: ${directoryPath}`);
+  }
+  await fs.rm(directoryPath, { recursive: true, force: true });
+}
+
+async function ensureOwnedChunkStore(repoRoot: string): Promise<void> {
+  const storeRoot = path.join(repoRoot, STORE_ROOT_RELATIVE_PATH);
+  await assertSafeStorePath(repoRoot, storeRoot);
+  const ownerPath = path.join(storeRoot, STORE_OWNER_FILE);
+  if (await pathExists(storeRoot)) {
+    const stat = await fs.lstat(storeRoot);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      throw new Error('Reserved chunk store path is not a regular directory.');
+    }
+    if (await pathExists(ownerPath)) {
+      if (!(await hasOwnedChunkStore(repoRoot))) {
+        throw new Error('Reserved chunk store has an invalid ownership marker.');
+      }
+      return;
+    }
+    const entries = await fs.readdir(storeRoot);
+    if (entries.length > 0) {
+      throw new Error('Reserved chunk store path already contains unowned data.');
+    }
+  }
+  await fs.mkdir(storeRoot, { recursive: true, mode: 0o700 });
+  await fs.writeFile(ownerPath, STORE_OWNER_CONTENT, { flag: 'wx', mode: 0o600 });
+}
+
+async function hasOwnedChunkStore(repoRoot: string): Promise<boolean> {
+  const ownerPath = path.join(repoRoot, STORE_ROOT_RELATIVE_PATH, STORE_OWNER_FILE);
+  const stat = await fs.lstat(ownerPath).catch(() => null);
+  if (!stat?.isFile() || stat.isSymbolicLink() || stat.size > POINTER_LIMIT) return false;
+  const content = await fs.readFile(ownerPath, 'utf8').catch(() => '');
+  return content === STORE_OWNER_CONTENT;
+}
+
+async function assertSafeStorePath(repoRoot: string, targetPath: string): Promise<void> {
+  const resolvedRoot = path.resolve(repoRoot);
+  const resolvedTarget = path.resolve(targetPath);
+  const relative = path.relative(resolvedRoot, resolvedTarget);
+  if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error('Chunk store path escapes the repository.');
+  }
+
+  const realRoot = await fs.realpath(resolvedRoot);
+  let current = resolvedRoot;
+  for (const segment of relative.split(path.sep).filter(Boolean)) {
+    current = path.join(current, segment);
+    const stat = await fs.lstat(current).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') return null;
+      throw error;
+    });
+    if (!stat) return;
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Chunk store path contains a symlink: ${current}`);
+    }
+    const realCurrent = await fs.realpath(current);
+    const realRelative = path.relative(realRoot, realCurrent);
+    if (
+      realRelative === '..' ||
+      realRelative.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(realRelative)
+    ) {
+      throw new Error('Chunk store path resolves outside the repository.');
+    }
+  }
+}
+
+async function assertRegularFile(filePath: string, label: string): Promise<Stats> {
+  const stat = await fs.lstat(filePath);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error(`${label} is not a regular file: ${filePath}`);
+  }
+  return stat;
+}
+
+function assertRepoRelativePath(repoRoot: string, repoPath: string): string {
+  const relative = path.relative(path.resolve(repoRoot), path.resolve(repoPath));
+  if (
+    !relative ||
+    relative === '..' ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
+    throw new Error(`Session path is outside the repository: ${repoPath}`);
+  }
+  if (isChunkStorePath(repoRoot, repoPath)) {
+    throw new Error('Session path overlaps the reserved chunk store.');
+  }
+  return relative.split(path.sep).join('/');
+}
+
+function chunkStorePath(repoRoot: string, id: string): string {
+  if (!SHA256_PATTERN.test(id)) throw new Error('Invalid chunk store identifier.');
+  return path.join(repoRoot, STORE_RELATIVE_PATH, id);
+}
+
+function chunkName(index: number): string {
+  return `${String(index).padStart(6, '0')}.part`;
+}
+
+export function createChunkId(relativePath: string, sha256: string): string {
+  if (!SHA256_PATTERN.test(sha256)) throw new Error('Invalid chunk SHA-256.');
+  const portablePath = relativePath.replace(/\\/gu, '/').replace(/^\.\//u, '');
+  return crypto.createHash('sha256').update(portablePath).update('\0').update(sha256).digest('hex');
+}
+
+async function copyRegularFileAtomic(
+  sourcePath: string,
+  destinationPath: string,
+  mode: number,
+  expectedStat: Stats
+): Promise<void> {
+  await fs.mkdir(path.dirname(destinationPath), { recursive: true });
+  const tempPath = `${destinationPath}.tmp-${process.pid}-${crypto.randomUUID()}`;
+  const source = await fs.open(sourcePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  let destination: Awaited<ReturnType<typeof fs.open>> | null = null;
+  try {
+    const openedStat = await source.stat();
+    if (!sameFileSnapshot(openedStat, expectedStat)) {
+      throw new Error(`Session source changed before it could be copied: ${sourcePath}`);
+    }
+    destination = await fs.open(
+      tempPath,
+      fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY,
+      0o600
+    );
+    const buffer = Buffer.allocUnsafe(DEFAULT_OPTIONS.bufferBytes);
+    let offset = 0;
+    while (offset < expectedStat.size) {
+      const length = Math.min(buffer.length, expectedStat.size - offset);
+      const { bytesRead } = await source.read(buffer, 0, length, offset);
+      if (bytesRead === 0) throw new Error(`Session source shrank while copying: ${sourcePath}`);
+      await writeAll(destination, buffer.subarray(0, bytesRead));
+      offset += bytesRead;
+    }
+    const finalStat = await source.stat();
+    if (!sameFileSnapshot(finalStat, expectedStat)) {
+      throw new Error(`Session source changed while copying: ${sourcePath}`);
+    }
+    await destination.sync();
+    await destination.close();
+    destination = null;
+    await fs.chmod(tempPath, mode);
+    await replaceFile(tempPath, destinationPath);
+  } catch (error) {
+    await destination?.close().catch(() => undefined);
+    await fs.rm(tempPath, { force: true });
+    throw error;
+  } finally {
+    await source.close();
+  }
+}
+
+function sameFileSnapshot(left: Stats, right: Stats): boolean {
+  return (
+    left.size === right.size &&
+    left.mtimeMs === right.mtimeMs &&
+    left.ctimeMs === right.ctimeMs &&
+    left.dev === right.dev &&
+    left.ino === right.ino
+  );
+}
+
+async function writeFileAtomic(filePath: string, content: string, mode: number): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const tempPath = `${filePath}.tmp-${process.pid}-${crypto.randomUUID()}`;
+  try {
+    await fs.writeFile(tempPath, content, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
+    await fs.chmod(tempPath, mode);
+    await replaceFile(tempPath, filePath);
+  } catch (error) {
+    await fs.rm(tempPath, { force: true });
+    throw error;
+  }
+}
+
+async function writeAll(
+  handle: Awaited<ReturnType<typeof fs.open>>,
+  buffer: Uint8Array
+): Promise<void> {
+  let offset = 0;
+  while (offset < buffer.length) {
+    const { bytesWritten } = await handle.write(buffer, offset, buffer.length - offset);
+    if (bytesWritten === 0) throw new Error('Unable to make progress while writing chunk data.');
+    offset += bytesWritten;
+  }
+}
+
+async function replaceFile(sourcePath: string, destinationPath: string): Promise<void> {
+  const backupPath = `${destinationPath}.backup-${process.pid}-${crypto.randomUUID()}`;
+  const destinationExists = await pathExists(destinationPath);
+  if (destinationExists) await fs.rename(destinationPath, backupPath);
+  try {
+    await fs.rename(sourcePath, destinationPath);
+    if (destinationExists) await fs.rm(backupPath, { force: true });
+  } catch (error) {
+    if (destinationExists && !(await pathExists(destinationPath))) {
+      await fs.rename(backupPath, destinationPath);
+    }
+    throw error;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/sync/paths.ts
+++ b/src/sync/paths.ts
@@ -28,6 +28,7 @@ export interface SyncItem {
   isSecret: boolean;
   isConfigFile: boolean;
   preserveWhenMissing?: boolean;
+  chunkLargeFiles?: boolean;
 }
 
 export interface ExtraPathPlan {
@@ -288,6 +289,7 @@ export function buildSyncPlan(
         isSecret: true,
         isConfigFile: false,
         preserveWhenMissing: true,
+        chunkLargeFiles: true,
       });
 
       for (const dirName of SESSION_DIRS) {
@@ -298,6 +300,7 @@ export function buildSyncPlan(
           isSecret: true,
           isConfigFile: false,
           preserveWhenMissing: true,
+          chunkLargeFiles: dirName === 'storage/message',
         });
       }
     }

--- a/src/sync/repo-history.test.ts
+++ b/src/sync/repo-history.test.ts
@@ -1,0 +1,128 @@
+import { exec, spawnSync } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import type { PluginInput } from '@opencode-ai/plugin';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { inspectOversizedUnpushedHistory } from './repo.js';
+
+const roots: string[] = [];
+const execAsync = promisify(exec);
+const shell = createTestShell();
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe('oversized unpushed Git history inspection', () => {
+  it('finds an oversized blob in commits ahead of the remote branch', async () => {
+    const fixture = await createGitFixture();
+    await fs.mkdir(path.join(fixture.local, 'data'), { recursive: true });
+    await fs.writeFile(path.join(fixture.local, 'data', 'opencode.db'), Buffer.alloc(32, 1));
+    git(fixture.local, 'add', '-A');
+    git(fixture.local, 'commit', '-m', 'sync sessions');
+
+    const result = await inspectOversizedUnpushedHistory(shell, fixture.local, 'main', 16);
+    expect(result).toEqual({
+      oversizedPaths: ['data/opencode.db'],
+      unpushedCommits: 1,
+      remoteExists: true,
+    });
+  });
+
+  it('reports oversized paths containing newlines without truncating them', async () => {
+    const fixture = await createGitFixture();
+    const unusualPath = path.join(fixture.local, 'data', 'message\ncontinued.json');
+    await fs.mkdir(path.dirname(unusualPath), { recursive: true });
+    await fs.writeFile(unusualPath, Buffer.alloc(32, 1));
+    git(fixture.local, 'add', '-A');
+    git(fixture.local, 'commit', '-m', 'sync unusual session');
+
+    const result = await inspectOversizedUnpushedHistory(shell, fixture.local, 'main', 16);
+    expect(result.oversizedPaths).toEqual(['data/message\ncontinued.json']);
+  });
+
+  it('does not report oversized blobs that are already on the remote', async () => {
+    const fixture = await createGitFixture();
+    await fs.mkdir(path.join(fixture.local, 'data'), { recursive: true });
+    await fs.writeFile(path.join(fixture.local, 'data', 'opencode.db'), Buffer.alloc(32, 1));
+    git(fixture.local, 'add', '-A');
+    git(fixture.local, 'commit', '-m', 'published sessions');
+    git(fixture.local, 'push', 'origin', 'main');
+    git(fixture.local, 'fetch', 'origin');
+
+    const result = await inspectOversizedUnpushedHistory(shell, fixture.local, 'main', 16);
+    expect(result.oversizedPaths).toEqual([]);
+    expect(result.unpushedCommits).toBe(0);
+  });
+
+  it('inspects an unpublished initial branch without including other remote history', async () => {
+    const fixture = await createGitFixture();
+    git(fixture.local, 'checkout', '--orphan', 'sessions');
+    git(fixture.local, 'rm', '-rf', '.');
+    await fs.writeFile(path.join(fixture.local, 'message.json'), Buffer.alloc(32, 2));
+    git(fixture.local, 'add', '-A');
+    git(fixture.local, 'commit', '-m', 'initial sessions');
+
+    const result = await inspectOversizedUnpushedHistory(shell, fixture.local, 'sessions', 16);
+    expect(result).toEqual({
+      oversizedPaths: ['message.json'],
+      unpushedCommits: 1,
+      remoteExists: false,
+    });
+  });
+});
+
+async function createGitFixture(): Promise<{ root: string; local: string; remote: string }> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'opencode-synced-history-'));
+  roots.push(root);
+  const remote = path.join(root, 'remote.git');
+  const seed = path.join(root, 'seed');
+  const local = path.join(root, 'local');
+  git(root, 'init', '--bare', remote);
+  git(root, 'clone', remote, seed);
+  git(seed, 'config', 'user.email', 'test@example.com');
+  git(seed, 'config', 'user.name', 'Test User');
+  await fs.writeFile(path.join(seed, 'README.md'), 'seed\n');
+  git(seed, 'add', '-A');
+  git(seed, 'commit', '-m', 'seed');
+  git(seed, 'branch', '-M', 'main');
+  git(seed, 'push', '-u', 'origin', 'main');
+  git(root, 'clone', '--branch', 'main', remote, local);
+  git(local, 'config', 'user.email', 'test@example.com');
+  git(local, 'config', 'user.name', 'Test User');
+  return { root, local, remote };
+}
+
+function git(cwd: string, ...args: string[]): void {
+  const result = spawnSync('git', ['-C', cwd, ...args], {
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) throw new Error(result.stderr);
+}
+
+interface TestShellCommand extends Promise<{ stdout: string; stderr: string }> {
+  quiet: () => TestShellCommand;
+  text: () => Promise<string>;
+}
+
+function createTestShell(): PluginInput['$'] {
+  const testShell = (strings: TemplateStringsArray, ...values: unknown[]): TestShellCommand => {
+    const command = strings.reduce(
+      (result, segment, index) =>
+        result + segment + (index < values.length ? shellQuote(values[index]) : ''),
+      ''
+    );
+    const execution = execAsync(command) as unknown as TestShellCommand;
+    execution.quiet = () => execution;
+    execution.text = async () => (await execution).stdout;
+    return execution;
+  };
+  return testShell as unknown as PluginInput['$'];
+}
+
+function shellQuote(value: unknown): string {
+  return `'${String(value).replaceAll("'", `'\\''`)}'`;
+}

--- a/src/sync/repo.ts
+++ b/src/sync/repo.ts
@@ -21,6 +21,16 @@ export interface RepoUpdateResult {
   branch: string;
 }
 
+export interface OversizedHistoryInspection {
+  oversizedPaths: string[];
+  unpushedCommits: number;
+  remoteExists: boolean;
+}
+
+const DEFAULT_MAX_GIT_BLOB_BYTES = 95 * 1024 * 1024;
+const MAX_RECOVERY_COMMITS = 100;
+const MAX_RECOVERY_TREE_ENTRIES = 200_000;
+
 type Shell = PluginInput['$'];
 
 export async function isRepoCloned(repoDir: string): Promise<boolean> {
@@ -255,6 +265,78 @@ export async function pushBranch($: Shell, repoDir: string, branch: string): Pro
   } catch (error) {
     throw new SyncCommandError(`Failed to push changes: ${formatError(error)}`);
   }
+}
+
+export async function inspectOversizedUnpushedHistory(
+  $: Shell,
+  repoDir: string,
+  branch: string,
+  maxBlobBytes = DEFAULT_MAX_GIT_BLOB_BYTES
+): Promise<OversizedHistoryInspection> {
+  assertValidRepoBranch(branch);
+  if (!Number.isSafeInteger(maxBlobBytes) || maxBlobBytes <= 0) {
+    throw new SyncCommandError('Invalid oversized Git blob safety limit.');
+  }
+
+  const remoteExists = await hasRemoteBranch($, repoDir, branch);
+  try {
+    await $`git -C ${repoDir} rev-parse --verify HEAD`.quiet();
+  } catch {
+    return { oversizedPaths: [], unpushedCommits: 0, remoteExists };
+  }
+  let revisions: string[];
+  try {
+    const output = remoteExists
+      ? await $`git -C ${repoDir} rev-list --max-count=${MAX_RECOVERY_COMMITS + 1} origin/${branch}..HEAD`
+          .quiet()
+          .text()
+      : await $`git -C ${repoDir} rev-list --max-count=${MAX_RECOVERY_COMMITS + 1} HEAD --not --remotes=origin`
+          .quiet()
+          .text();
+    revisions = output
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+  } catch (error) {
+    throw new SyncCommandError(`Failed to inspect unpushed Git history: ${formatError(error)}`);
+  }
+
+  if (revisions.length > MAX_RECOVERY_COMMITS) {
+    throw new SyncCommandError(
+      `Refusing to inspect more than ${MAX_RECOVERY_COMMITS} unpushed commits automatically.`
+    );
+  }
+
+  const oversizedPaths = new Set<string>();
+  let inspectedEntries = 0;
+  try {
+    for (const revision of revisions) {
+      const output = await $`git -C ${repoDir} ls-tree -r -l -z --full-tree ${revision}`
+        .quiet()
+        .text();
+      for (const entry of output.split('\0')) {
+        if (!entry) continue;
+        inspectedEntries += 1;
+        if (inspectedEntries > MAX_RECOVERY_TREE_ENTRIES) {
+          throw new SyncCommandError('Unpushed history exceeds the automatic recovery scan limit.');
+        }
+        const match = entry.match(/^\d+\s+blob\s+[a-f0-9]+\s+(\d+)\t([\s\S]+)$/u);
+        if (!match) continue;
+        const size = Number(match[1]);
+        const filePath = match[2] as string;
+        if (Number.isSafeInteger(size) && size > maxBlobBytes) oversizedPaths.add(filePath);
+      }
+    }
+  } catch (error) {
+    if (error instanceof SyncCommandError) throw error;
+    throw new SyncCommandError(`Failed to scan unpushed Git objects: ${formatError(error)}`);
+  }
+
+  return {
+    oversizedPaths: [...oversizedPaths].sort(),
+    unpushedCommits: revisions.length,
+    remoteExists,
+  };
 }
 
 async function getCurrentBranch($: Shell, repoDir: string): Promise<string> {

--- a/src/sync/service.test.ts
+++ b/src/sync/service.test.ts
@@ -211,4 +211,72 @@ describe('explicit Git remote service flow', () => {
       ).resolves.toContain('opencode-synced configured');
     });
   }, 30_000);
+
+  it('fails closed with recovery instructions for an oversized unpushed session commit', async () => {
+    await withIsolatedEnvironment(async (root) => {
+      const testShell = createTestShell();
+      const remotePath = path.join(root, 'sync-remote.git');
+      await testShell`git init --bare ${remotePath}`.quiet();
+
+      const machineHome = path.join(root, 'machine');
+      useIsolatedHome(machineHome);
+      const locations = resolveSyncLocations();
+      await fs.mkdir(locations.configRoot, { recursive: true });
+      await fs.writeFile(path.join(locations.configRoot, 'opencode.json'), '{}\n');
+      const service = createSyncService({ client: createClient(), $: testShell });
+      await service.init({
+        repo: remotePath,
+        branch: 'main',
+        includeSecrets: true,
+        includeSessions: true,
+        acknowledgePrivateRemote: true,
+      });
+
+      const config = await loadSyncConfig(locations);
+      if (!config) throw new Error('Expected sync config.');
+      const repoRoot = config.localRepoPath ?? locations.defaultRepoDir;
+      const repoMessage = path.join(repoRoot, 'data', 'storage', 'message', 'failed.json');
+      const localMessage = path.join(
+        locations.xdg.dataDir,
+        'opencode',
+        'storage',
+        'message',
+        'failed.json'
+      );
+      await fs.mkdir(path.dirname(repoMessage), { recursive: true });
+      await fs.mkdir(path.dirname(localMessage), { recursive: true });
+      await fs.writeFile(repoMessage, '');
+      await fs.truncate(repoMessage, 96 * 1024 * 1024);
+      await fs.copyFile(repoMessage, localMessage);
+      await testShell`git -C ${repoRoot} add -A`.quiet();
+      await testShell`git -C ${repoRoot} commit -m ${'sync oversized session'}`.quiet();
+
+      let message = '';
+      try {
+        await service.push();
+      } catch (error) {
+        message = error instanceof Error ? error.message : String(error);
+      }
+      expect(message).toMatch(/Push stopped:.*data\/storage\/message\/failed\.json/su);
+      expect(message).toMatch(/git branch opencode-synced-oversized-backup-/u);
+      expect(message).toMatch(/git reset --soft origin\/main/u);
+
+      await testShell`git -C ${repoRoot} add -A`.quiet();
+      await testShell`git -C ${repoRoot} commit -m ${'sync chunk representation'}`.quiet();
+      await writeSyncConfig(locations, {
+        ...config,
+        sessionBackend: { type: 'turso' },
+      });
+      let cleanupMessage = '';
+      try {
+        await service.sessionsCleanupGit();
+      } catch (error) {
+        cleanupMessage = error instanceof Error ? error.message : String(error);
+      }
+      expect(cleanupMessage).toMatch(/Push stopped:.*data\/storage\/message\/failed\.json/su);
+      expect(cleanupMessage).toContain(
+        'The working tree has removed the deprecated Git session paths.'
+      );
+    });
+  }, 30_000);
 });

--- a/src/sync/service.ts
+++ b/src/sync/service.ts
@@ -32,6 +32,7 @@ import {
   hasAnyRemoteBranches,
   hasLocalChanges,
   hasRemoteBranch,
+  inspectOversizedUnpushedHistory,
   isExplicitGitRemote,
   isGitHubRepoConfig,
   isRepoCloned,
@@ -806,6 +807,7 @@ export function createSyncService(ctx: SyncServiceContext): SyncService {
             overridesPath: locations.overridesPath,
             allowMcpSecrets: canCommitMcpSecrets(config),
           });
+          await assertNoOversizedUnpushedHistory(ctx.$, repoRoot, branch);
 
           const dirty = await hasLocalChanges(ctx.$, repoRoot);
           if (dirty) {
@@ -1041,6 +1043,7 @@ export function createSyncService(ctx: SyncServiceContext): SyncService {
           overridesPath: locations.overridesPath,
           allowMcpSecrets: canCommitMcpSecrets(config),
         });
+        await assertNoOversizedUnpushedHistory(ctx.$, repoRoot, branch);
 
         const dirty = await hasLocalChanges(ctx.$, repoRoot);
         if (!dirty) {
@@ -1335,12 +1338,18 @@ export function createSyncService(ctx: SyncServiceContext): SyncService {
           await fs.rm(target, { recursive: true, force: true });
         }
 
+        const branch = await resolveBranch(ctx, config, repoRoot);
+        await assertNoOversizedUnpushedHistory(
+          ctx.$,
+          repoRoot,
+          branch,
+          'The working tree has removed the deprecated Git session paths.'
+        );
         const dirty = await hasLocalChanges(ctx.$, repoRoot);
         if (!dirty) {
           return 'No deprecated Git session artifacts were found.';
         }
 
-        const branch = await resolveBranch(ctx, config, repoRoot);
         await commitAll(ctx.$, repoRoot, 'chore: remove deprecated git session artifacts');
         await pushBranch(ctx.$, repoRoot, branch);
         await updateState(locations, { lastPush: new Date().toISOString() });
@@ -1461,6 +1470,7 @@ async function runStartup(
     overridesPath: locations.overridesPath,
     allowMcpSecrets: canCommitMcpSecrets(config),
   });
+  await assertNoOversizedUnpushedHistory(ctx.$, repoRoot, branch);
   const changes = await hasLocalChanges(ctx.$, repoRoot);
   if (!changes) {
     log.debug('No local changes to push');
@@ -1474,6 +1484,61 @@ async function runStartup(
   await updateState(locations, {
     lastPush: new Date().toISOString(),
   });
+}
+
+async function assertNoOversizedUnpushedHistory(
+  $: Shell,
+  repoRoot: string,
+  branch: string,
+  preparedMessage = 'The working tree already contains the safe chunk representation.'
+): Promise<void> {
+  const inspection = await inspectOversizedUnpushedHistory($, repoRoot, branch);
+  if (inspection.oversizedPaths.length === 0) return;
+
+  const backupBranch = `opencode-synced-oversized-backup-${Date.now()}`;
+  const paths = inspection.oversizedPaths.map((filePath) => `  - ${filePath}`).join('\n');
+  const unsupportedPaths = inspection.oversizedPaths.filter(
+    (filePath) =>
+      !['data/opencode.db', 'data/opencode.db-wal', 'data/opencode.db-shm'].includes(filePath) &&
+      !filePath.startsWith('data/storage/message/')
+  );
+  const commands = inspection.remoteExists
+    ? [
+        `cd ${shellQuoteForInstructions(repoRoot)}`,
+        `git branch ${backupBranch}`,
+        `git reset --soft origin/${branch}`,
+        'git add -A',
+        'git commit -m "fix: recover chunked session files"',
+        `git push -u origin ${branch}`,
+      ]
+    : [
+        `cd ${shellQuoteForInstructions(repoRoot)}`,
+        `git branch ${backupBranch}`,
+        `git checkout --orphan ${branch}-recovered`,
+        'git add -A',
+        'git commit -m "fix: recover chunked session files"',
+        `git branch -M ${branch}`,
+        `git push -u origin ${branch}`,
+      ];
+  throw new SyncCommandError(
+    [
+      'Push stopped: unpushed commits still contain oversized Git blobs:',
+      paths,
+      '',
+      'opencode-synced will not rewrite local history automatically.',
+      unsupportedPaths.length === 0
+        ? preparedMessage
+        : `Before rebuilding, replace or remove these unsupported oversized working-tree paths: ${unsupportedPaths.join(', ')}`,
+      'To retain an exact backup and rebuild only the unpushed commits, review and run:',
+      ...commands.map((command) => `  ${command}`),
+      '',
+      `The original history remains available on branch ${backupBranch}.`,
+    ].join('\n')
+  );
+}
+
+function shellQuoteForInstructions(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
 async function getConfigOrThrow(


### PR DESCRIPTION
## Summary

- replace oversized `opencode.db` bundles and legacy `storage/message` files with a versioned, content-addressed chunk representation
- validate strict count/size/mode/SHA-256 metadata, reject symlinks and corrupt/missing/extra parts, and reconstruct through staged atomic replacement
- protect the reserved chunk namespace with a versioned ownership marker, bounded known-location cleanup, and realpath containment
- detect oversized blobs in unpushed Git ancestry and fail closed with exact backup-branch/rebuild commands instead of silently rewriting history

This is a fresh replacement for the already-closed #48. It preserves plain legacy session files and normal non-session files.

Closes #45

## Safety and compatibility

- chunks start above 50 MiB and are at most 40 MiB each
- v1 pointers cap reconstructed files at 4 GiB and 128 parts
- database, WAL, and SHM files validate and install or roll back as one bundle
- file modes are retained in pointer metadata
- stale/corrupt pointers, source mutation, filename collisions, namespace collisions, and ancestor symlink escapes fail closed
- old failed oversized commits are not rewritten automatically; the error first instructs creation of an exact backup branch, then rebuilds only unpushed history when the user elects to run the commands

## Verification

- `bun run check`
- `bun test` — 129 passed, 0 failed
- `bun run build`
- independent final focused audit — 33 passed, 0 failed; no blocker
- realistic production-threshold two-home exercise: 52 MiB `opencode.db` and 51 MiB legacy message round-tripped A→B and modified B→A with matching SHA-256 and modes 0600/0640; largest committed blob was 41,943,040 bytes
- isolated two-instance GitHub E2E — passed; sentinel replicated and ephemeral private repo deleted
- isolated GitHub E2E with `--enable-sessions` — passed; repo session titles verified after link and pull, with expected restart requirement for the live local database; ephemeral private repo deleted

Expected harness-only warnings were the unsecured loopback test server, duplicate copied sandbox skill, live local DB restart requirement, and local `AGENTS.md` lag while repo replication was confirmed.