### PR TITLE
fix: unblock release publication workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -240,6 +240,7 @@ jobs:
     # an immutable npm version, so the exact packed artifact must pass prepublish-smoke first.
     needs: publish
     permissions:
+      actions: read
       contents: read
     uses: ./.github/workflows/opencode-smoke.yml
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,8 +65,10 @@ jobs:
         if: needs.process.outputs.prs_created == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_PR_NUMBER: ${{ fromJSON(needs.process.outputs.release_pr).number }}
+          RELEASE_PR_JSON: ${{ needs.process.outputs.release_pr }}
         run: |
+          RELEASE_PR_NUMBER=$(jq -er '.number | select(type == "number")' \
+            <<<"$RELEASE_PR_JSON")
           RELEASE_PR_SHA=$(gh api \
             "repos/${GITHUB_REPOSITORY}/pulls/${RELEASE_PR_NUMBER}" \
             --jq '.head.sha')

--- a/package.json
+++ b/package.json
@@ -22,9 +22,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "dependencies": {
     "@opencode-ai/plugin": "1.0.85"
   },
@@ -51,8 +49,6 @@
     "prepare": "husky"
   },
   "lint-staged": {
-    "*.{js,ts,json}": [
-      "biome check --write --no-errors-on-unmatched"
-    ]
+    "*.{js,ts,json}": ["biome check --write --no-errors-on-unmatched"]
   }
 }

--- a/src/release-workflows.test.ts
+++ b/src/release-workflows.test.ts
@@ -64,4 +64,18 @@ describe('release workflows', () => {
     expect(releaseWorkflow).toContain("outputs.prs_created == 'true'");
     expect(readProjectFile('.mise/tasks/setup')).toContain('bun install --frozen-lockfile');
   });
+
+  it('does not parse an absent release PR before the prerelease step condition is applied', () => {
+    expect(releaseWorkflow).not.toContain('fromJSON(needs.process.outputs.release_pr)');
+    expect(releaseWorkflow).toContain(
+      'RELEASE_PR_JSON: $' + '{{ needs.process.outputs.release_pr }}'
+    );
+    expect(releaseWorkflow).toContain('jq -er \'.number | select(type == "number")\'');
+  });
+
+  it('allows the post-publish smoke workflow to download the published artifact', () => {
+    expect(publishWorkflow).toMatch(
+      /postpublish-smoke:[\s\S]*?permissions:\n {6}actions: read\n {6}contents: read/
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- defer parsing the release PR payload until the prerelease dispatch step actually runs
- grant the post-publish smoke workflow permission to download Actions artifacts
- restore formatter-normalized `package.json` layout after the generated [release PR #38](https://github.com/iHildy/opencode-synced/pull/38)
- add regression coverage for both workflow failures

## Verification

- `bun run check`
- `bun test` (195 passed)
- `bun run build`
- `actionlint` on the release, publish, and smoke workflows
- isolated two-instance GitHub E2E passed

## Failure evidence

- [release dispatch failure](https://github.com/iHildy/opencode-synced/actions/runs/33349824836)
- [publish workflow startup failure](https://github.com/iHildy/opencode-synced/actions/runs/33349843132)