### PR TITLE
fix: preserve release version in smoke workflow

### DIFF
--- a/.github/workflows/opencode-smoke.yml
+++ b/.github/workflows/opencode-smoke.yml
@@ -47,7 +47,7 @@ jobs:
         id: version
         env:
           ARTIFACT_NAME: ${{ inputs.artifact }}
-          REQUESTED_VERSION: ${{ github.event_name == 'workflow_call' && inputs.version || '' }}
+          REQUESTED_VERSION: ${{ inputs.version }}
           REQUESTED_TAG: ${{ inputs.tag }}
         run: |
           if [ -n "$ARTIFACT_NAME" ]; then

--- a/src/release-workflows.test.ts
+++ b/src/release-workflows.test.ts
@@ -78,4 +78,9 @@ describe('release workflows', () => {
       /postpublish-smoke:[\s\S]*?permissions:\n {6}actions: read\n {6}contents: read/
     );
   });
+
+  it('preserves the requested version across reusable workflow event types', () => {
+    expect(smokeWorkflow).toMatch(/REQUESTED_VERSION: \$\{\{ inputs\.version \}\}/);
+    expect(smokeWorkflow).not.toContain("github.event_name == 'workflow_call' && inputs.version");
+  });
 });


### PR DESCRIPTION
## Summary

- pass the typed reusable-workflow version input directly to the smoke test
- remove the event-name check that discarded the version during a manual release run
- add regression coverage for reusable workflow input propagation

## Verification

- `bun run check`
- `bun test` (196 passed)
- `bun run build`
- `actionlint` on the smoke and publish workflows
- plugin runtime is unchanged; the isolated two-instance E2E passed on the preceding workflow repair

## Failure evidence

- [pre-publish smoke failure](https://github.com/iHildy/opencode-synced/actions/runs/33350276969)